### PR TITLE
feat: add debug-recovery skill (pipeline failure branch + standalone debugger)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for any AI agent — Claude, Codex, Gemini, OpenCode, Pi, or otherwise 
 
 ## What this repo is
 
-`vibekit` is a 14-skill plugin that turns a short user intent into a verified, user-approved feature through a disciplined pipeline: brainstorm → plan → isolate → exec → verify → review → integrate. The orchestrator is `vibe`; every other skill composes beneath it. `ralph-loop` is its autonomous-driver peer — wraps `vibe` in a bounded persistence loop with classifier + thrashing critic, halts on genuine ambiguity, never bypasses review-pack sign-off. `memory-dual` is the cross-cutting durable-knowledge surface (atomic facts + compound documents + working notepad, one storage convention). `vibekit-doctor` is a diagnostic utility. `using-vibekit` is the auto-trigger priming layer — auto-loaded by every supported runtime so the trigger map for the rest of the pipeline is always in context.
+`vibekit` is a 15-skill plugin that turns a short user intent into a verified, user-approved feature through a disciplined pipeline: brainstorm → plan → isolate → exec → verify → review → integrate. The orchestrator is `vibe`; every other skill composes beneath it. `ralph-loop` is its autonomous-driver peer — wraps `vibe` in a bounded persistence loop with classifier + thrashing critic, halts on genuine ambiguity, never bypasses review-pack sign-off. `memory-dual` is the cross-cutting durable-knowledge surface (atomic facts + compound documents + working notepad, one storage convention). `vibekit-doctor` is a diagnostic utility. `using-vibekit` is the auto-trigger priming layer — auto-loaded by every supported runtime so the trigger map for the rest of the pipeline is always in context.
 
 ## Repository layout
 
@@ -50,6 +50,7 @@ Every skill is **self-contained**. Do not reference external plugins (superpower
 | `isolate` | Worktree or branch per run; clean slate, cheap rollback. |
 | `memory-dual` | Durable project knowledge under `.vibekit/memory/` — atomic facts and compound documents in one storage convention, plus working notepad; keyword + tag + type search, `[[key]]` cross-links, audit pass. |
 | `vibekit-doctor` | Diagnostic health check — skill files, runtime registrations, `.vibekit/` health, `docs/` subdirs, authoring contracts. Read-only by default; `--fix` for safe repairs. |
+| `debug-recovery` | Pipeline failure branch + standalone debugger. Stop-the-line root-cause triage with one fresh read-only confirmation dispatch; produces a proven diagnosis and routes the fix to `exec-dispatch`/`plan-write`. Never edits code. |
 | `ralph-loop` | Autonomous-driver peer to `vibe` — bounded persistence loop with blocker classifier and thrashing critic; same gates, same sign-off, no shortcuts. Cross-runtime with degraded checkpoint mode where native loops are absent. |
 | `using-vibekit` | Auto-trigger priming layer. Auto-loaded by SessionStart hook (Claude Code), `@`-import (Gemini), native discovery (Codex), message transform (opencode), and `before_agent_start` extension (Pi) so the trigger map and 1%-chance rule are always in context. Not user-invoked. |
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,6 +21,9 @@ For implementation planning and execution:
 @./skills/review-pack/SKILL.md
 @./skills/finish-branch/SKILL.md
 
+For the pipeline failure branch and standalone debugging (root-cause triage, routes fixes to exec/plan):
+@./skills/debug-recovery/SKILL.md
+
 For durable project knowledge — atomic facts, compound documents, working notepad:
 @./skills/memory-dual/SKILL.md
 

--- a/skills/debug-recovery/SKILL.md
+++ b/skills/debug-recovery/SKILL.md
@@ -18,6 +18,8 @@ A confident guess is not a root cause. Every diagnosis here is backed by verbati
 - **Pipeline failure branch:** `verify-gate` returns a `not satisfied` or `partial` requirement, OR an `exec-dispatch` subagent report contains a failing test (`result: fail`) or a broken build.
 - **Standalone:** the user says "debug this", "why is this failing", or names a failing test, error, stack trace, or broken build outside a vibe run.
 
+**Precedence:** debug-recovery fires *after* `verify-gate` or `exec-dispatch` has already produced a failure — it consumes that failure, it does not compete with those skills and never pre-empts a passing `verify-gate`. A passing gate routes onward (review-pack); only a failing one routes here.
+
 Do NOT invoke for:
 - A feature that is working but slow or ugly — that is not a failure.
 - Applying a fix you already understand with certainty under a normal plan — route straight to `exec-dispatch`/`plan-write`.

--- a/skills/debug-recovery/SKILL.md
+++ b/skills/debug-recovery/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: debug-recovery
+description: Use when a verification or test fails and you need a disciplined response instead of guessing — fires as vibekit's pipeline failure branch (verify-gate not-satisfied, exec-dispatch test/build failure) and standalone when the user reports a bug, failing test, or broken build. Finds and proves a root cause with verbatim evidence, then routes the fix through exec-dispatch or plan-write. Never edits code itself.
+---
+
+# debug-recovery
+
+Follows: PEG (root-cause triage) + Karpathy (Think Before Coding, Goal-Driven) + Quad-Adapter (capabilities: fresh-context subagent dispatch).
+
+## Overview
+
+The vibe pipeline models the happy path. This skill is what runs when something **fails**. It stops the line, preserves evidence, finds and *proves* a root cause, then hands the fix to the existing gates. It never edits code — diagnosis is the product.
+
+A confident guess is not a root cause. Every diagnosis here is backed by verbatim evidence, exactly as `verify-gate` demands of verifications.
+
+## When to invoke
+
+- **Pipeline failure branch:** `verify-gate` returns a `not satisfied` or `partial` requirement, OR an `exec-dispatch` subagent report contains a failing test (`result: fail`) or a broken build.
+- **Standalone:** the user says "debug this", "why is this failing", or names a failing test, error, stack trace, or broken build outside a vibe run.
+
+Do NOT invoke for:
+- A feature that is working but slow or ugly — that is not a failure.
+- Applying a fix you already understand with certainty under a normal plan — route straight to `exec-dispatch`/`plan-write`.
+- Diagnosing a runtime/host bug rather than the code under test.
+
+## Core principle: evidence before diagnosis
+
+No requirement, hypothesis, or root cause is asserted without a real, quotable artifact. If you cannot quote the error, the failing test output, or the offending line, you do not yet have a diagnosis — you have a guess. Guesses do not get routed.
+
+## Stop-the-line procedure
+
+```
+1. STOP        — no new features, no speculative edits
+2. PRESERVE    — capture error/log/repro VERBATIM (never-compress)
+3. REPRODUCE   — make the failure happen reliably; if not, document conditions
+4. ISOLATE     — binary-search the diff/change history to the smallest culprit
+5. HYPOTHESIZE — name the root cause as a falsifiable claim + supporting evidence
+6. CONFIRM     — dispatch ONE fresh read-only subagent to refute the root cause
+7. ROUTE       — small fix → exec-dispatch brief; structural → plan-write
+8. GUARD       — the routed fix MUST include a regression test that fails pre-fix
+```
+
+Steps 1–5 run in this session — debugging is a stateful narrowing search, where each step depends on what the last one ruled out. Step 6 is the single dispatched confirmation. Step 7 hands off; this skill writes no code. Step 8 is a constraint carried into the routed brief or plan.
+
+**Re-hypothesis bound:** if step 6 refutes the root cause, return to step 5. After 3 refuted cycles on the same failure, stop and escalate to the user with everything ruled out so far. Do not loop indefinitely.
+
+### Step 4 — isolate, in practice
+
+When the failure followed a change, binary-search the history rather than reading every line:
+
+```
+git bisect / git log --oneline  — find the first bad commit
+git diff <last-good>..<first-bad> — narrow to the offending hunk
+```
+
+When there is no obvious change (intermittent / environmental), widen the race window: add timestamped logging around the suspected area, run under load, or run repeatedly to raise collision probability. Document the conditions if it stays non-reproducible — a `status: unreproducible` report is a valid outcome.
+
+## Confirmation dispatch
+
+Step 6 dispatches exactly one fresh, read-only subagent. Compile it through `brief-compiler`; process its return through `report-filter`. The brief:
+
+```
+ROLE: Root-cause confirmation reviewer, read-only.
+TASK: Try to REFUTE that <root_cause> is the cause of <failure>.
+CONSTRAINTS:
+  - Read-only. No edits, no commits.
+  - Default to refuted=true if the evidence is not conclusive.
+  - Base judgment on repo state + the cited evidence, not the diagnosis narrative.
+CONTEXT:
+  Failure: <verbatim error/test output>
+  Claimed root cause: <falsifiable claim>
+  Evidence: <file:line refs, diff hunks, repro steps>
+OUTPUT:
+  { "refuted": true|false, "reason": "<string>", "evidence": "<file:line or output>" }
+```
+
+`refuted: true` → return to step 5 (within the 3-cycle bound). `refuted: false` → proceed to route.
+
+## Diagnosis report schema
+
+The product of this skill. Returned through `report-filter` when fired inside the pipeline; surfaced to the user when standalone.
+
+```json
+{
+  "status": "diagnosed | unreproducible | escalate",
+  "failure": "<verbatim error/symptom>",
+  "reproduction": "<exact steps/command, or why not reproducible>",
+  "root_cause": "<falsifiable claim>",
+  "evidence": ["<file:line or verbatim output>"],
+  "confirmation": {"refuted": false, "reason": "<string>"},
+  "fix_route": "exec-dispatch | plan-write",
+  "guard_test": "<the regression test the fix must add>"
+}
+```
+
+## Routing the fix
+
+Once `status: diagnosed` and `confirmation.refuted: false`:
+
+- **Small, local fix** (a single function/file, no interface change) → route to `exec-dispatch`: hand it a one-task brief whose CONSTRAINTS carry the `guard_test` (the regression test that must fail pre-fix and pass post-fix).
+- **Structural fix** (crosses a module boundary, changes an interface, needs design) → route back to `plan-write`: the diagnosis becomes the problem statement for a new plan.
+- **`status: unreproducible`** → surface conditions to the user; do not route a fix into the dark.
+- **`status: escalate`** (3 refuted cycles) → surface everything ruled out and let the user decide.
+
+This skill never edits code, never commits a fix, and never marks a failure resolved on its own — the routed gate does that.
+
+## Never-compress list
+
+Verbatim, always: error messages, stack traces, test runner output, reproduction commands, diff hunks, the confirmation verdict's evidence, and the routing/escalation message to the user.
+
+## Runtime capability gate
+
+This skill needs: one fresh-context subagent dispatch (step 6).
+
+| Runtime | Fresh dispatch | Fallback |
+|---|---|---|
+| Claude Code | yes | n/a |
+| Codex | yes | n/a |
+| opencode | yes (provider-dependent) | n/a where present |
+| Gemini CLI | no | in-session fresh-prompt self-refutation with a hard separator, flagged degraded |
+| Pi | no | same degraded fallback |
+
+On a runtime lacking fresh dispatch, print this warning verbatim before degrading:
+
+> **Capability degraded.** Running on `<detected runtime>` which lacks `fresh-context subagent dispatch`. Falling back to `in-session self-refutation with hard separator`. Output may differ from a fully-supported run; the root-cause confirmation is not independent.
+
+Then continue with the fallback — never silently skip step 6.
+
+## Anti-patterns
+
+- Patching a symptom before isolating the cause. → Wrong. Run the procedure; the cause is what gets routed.
+- Routing a fix on an unconfirmed hypothesis. → Wrong. Step 6 must return `refuted: false` first.
+- Editing code "while you're in there". → Wrong. This skill diagnoses; the gate fixes.
+- Dropping the verbatim error to "summarize the bug". → Wrong. The evidence is the diagnosis.

--- a/skills/using-vibekit/SKILL.md
+++ b/skills/using-vibekit/SKILL.md
@@ -37,6 +37,8 @@ If the user says "skip the brainstorm" or "just write the code," follow the user
 | `review-pack` returned `yes` and user signed off on the diff | `finish-branch` |
 | Driving a vibe run autonomously across iterations | `ralph-loop` |
 | Storing, recalling, or auditing durable project knowledge | `memory-dual` |
+| `verify-gate` returns `not satisfied`/`partial`, or an `exec-dispatch` task fails its test/build | `debug-recovery` |
+| User reports a bug, failing test, broken build, or asks "why is this failing" | `debug-recovery` |
 | User reports vibekit feels broken, skills not firing, or cross-runtime drift | `vibekit-doctor` |
 
 ## Hard gates (never bypass)


### PR DESCRIPTION
## Summary
Adds `debug-recovery` — vibekit's pipeline failure branch and a standalone debugging skill. It produces a *proven* root-cause diagnosis and routes the fix through existing gates; it never edits code itself.

## Changes
- **`skills/debug-recovery/SKILL.md`** (new, canonical) — 8-step stop-the-line procedure (STOP → PRESERVE → REPRODUCE → ISOLATE → HYPOTHESIZE → CONFIRM → ROUTE → GUARD), a single fresh-context confirmation dispatch, the diagnosis JSON schema, routing rules (small fix → `exec-dispatch`, structural → `plan-write`), never-compress list, and a 5-runtime capability gate with a documented degraded fallback.
- **`skills/using-vibekit/SKILL.md`** — two auto-trigger-map rows (failure-branch + standalone).
- **`AGENTS.md`** — skill-table row; plugin count bumped 14 → 15.
- **`GEMINI.md`** — `@`-include for the new skill.
- Trigger-precedence note (fires *after* a verify-gate/exec failure; never pre-empts a passing gate).

## Testing
Prose/skill change — no JS test runner in this repo. Verification used structural `grep` assertions + `vibekit-doctor` checks: C1 (file integrity), C2 (registration parity), C3 (manifest glob + unchanged 7-stage descriptions), C8 (skill-count consistency = 15). Surgical-diff blast-radius audit returned `clean` (zero orphans). verify-gate verdict: **ready**.

## Follow-up
- Live eval of the installed skill (verify→debug→route round-trip; Gemini/Pi degraded fallback) — deferred post-merge per the spec's eval workflow.