### PR TITLE
chore(npm): prepare package for npm publish under @rizukirr scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Guardrails are non-negotiable. If the plan is wrong or the tests don't pass, the
 
 ## Install
 
+### Via npm
+
+Vibekit is published to npm as [`@rizukirr/vibekit`](https://www.npmjs.com/package/@rizukirr/vibekit) — a pinned, versioned alternative to the git and marketplace installs below. The published package bundles all 15 skills plus every runtime adapter (Claude Code, Codex, Gemini, Pi, OpenCode).
+
+```bash
+npm install @rizukirr/vibekit
+# or, to vendor it globally
+npm install -g @rizukirr/vibekit
+```
+
+This vendors the full skill set and adapters under `node_modules/@rizukirr/vibekit/`. Point your runtime at that path using the per-runtime steps below. Reach for npm when you want a specific released version pinned in a project; the marketplace and git methods below track `main` and are simpler for most setups.
+
 ### Claude Code
 
 From a marketplace that hosts this plugin:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vibekit",
+  "name": "@rizukirr/vibekit",
   "version": "0.5.0",
-  "description": "Token-efficient vibe-coding pipeline plugin for Pi and OpenCode.",
+  "description": "Token-efficient vibe-coding pipeline — 15 auto-triggered guardrail skills for Claude Code, Codex, Gemini, Pi, and OpenCode.",
   "type": "module",
   "main": ".opencode/plugins/vibekit.js",
   "license": "MIT",
@@ -16,6 +16,7 @@
   "files": [
     "skills/brainstorm-lean/",
     "skills/brief-compiler/",
+    "skills/debug-recovery/",
     "skills/exec-dispatch/",
     "skills/finish-branch/",
     "skills/isolate/",
@@ -30,8 +31,15 @@
     "skills/vibekit-doctor/",
     "commands/",
     "hooks/",
+    ".claude-plugin/",
+    ".codex/",
+    ".codex-plugin/",
     ".pi-plugin/",
     ".opencode/",
+    "gemini-extension.json",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
     "README.md",
     "LICENSE"
   ],
@@ -40,6 +48,11 @@
     "pi-package",
     "opencode-plugin",
     "ai-coding",
+    "vibe-coding",
+    "claude-code",
+    "codex",
+    "gemini",
+    "agent-skills",
     "skills"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Summary

Prepares the package to be published to npm. The unscoped name `vibekit` is already owned by an unrelated project on npm, so this publishes under the `@rizukirr` scope and turns the npm tarball into a universal install channel for all five runtimes.

## Changes

- **Scope the package name** → `@rizukirr/vibekit`. `npm whoami` is `rizukirr`, so publish rights resolve; `publishConfig.access` is already `public`.
- **Fix `files` whitelist bug** — `skills/debug-recovery/` was missing, so the skill would not have shipped despite existing on disk and being counted in the README. Verified via `npm pack --dry-run`.
- **Ship all five runtime adapters** (`.claude-plugin/`, `.codex/`, `.codex-plugin/`, `.pi-plugin/`, `.opencode/`, `gemini-extension.json`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) so a single `npm install` carries every runtime.
- **Broaden description + keywords** to reflect all supported runtimes.
- **README** — add a "Via npm" install subsection documenting `@rizukirr/vibekit`.

## Verification

- `npm pack --dry-run` → 50 files, 79KB, all 15 skills + 5 adapters present; no `external/`, `docs/`, `tests/`, or `.git/` leakage.
- `npm publish --dry-run` → resolves to `@rizukirr/vibekit` with `latest` tag and **public access**.
- `package.json` is valid JSON; versions still synced at `0.5.0` across all manifests.