### PR TITLE
fix(hooks): make SessionStart priming work on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,24 @@ jobs:
       # install step is needed.
       - name: Validate manifests, skills, and package contents
         run: npm run check
+
+  hook:
+    name: hook (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      # The SessionStart hook is the entire vibekit integration: if it fails to
+      # execute, every skill is inert with no visible error. The windows-latest
+      # leg is the only machine-executed proof that the polyglot wrapper's batch
+      # half works; nothing on a Unix dev box can verify it.
+      - name: Smoke-test the SessionStart hook
+        run: npm run check:hook

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\"",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "shell": "bash",
             "async": false
           }
         ]

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -16,22 +16,33 @@ if "%~1"=="" (
 )
 
 set "HOOK_DIR=%~dp0"
+set "HOOK_SCRIPT=%~1"
+
+REM Forward every argument after the first, preserving the caller's quoting.
+REM cmd has no "$@" equivalent: %* still includes %1, and shift does not
+REM affect %*, so split %* on its first token and keep the remainder.
+set "HOOK_ARGS="
+for /f "tokens=1,*" %%a in ("%*") do set "HOOK_ARGS=%%b"
+
+REM Bare `exit /b` propagates the real errorlevel. `exit /b %ERRORLEVEL%`
+REM would not: cmd expands %ERRORLEVEL% when it parses the whole
+REM parenthesised block, before any line inside it has run.
 
 REM Try Git for Windows bash in standard locations
 if exist "C:\Program Files\Git\bin\bash.exe" (
-    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
-    exit /b %ERRORLEVEL%
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%" %HOOK_ARGS%
+    exit /b
 )
 if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
-    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
-    exit /b %ERRORLEVEL%
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%" %HOOK_ARGS%
+    exit /b
 )
 
 REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
 where bash >nul 2>nul
 if %ERRORLEVEL% equ 0 (
-    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
-    exit /b %ERRORLEVEL%
+    bash "%HOOK_DIR%%HOOK_SCRIPT%" %HOOK_ARGS%
+    exit /b
 )
 
 REM No bash found - exit silently rather than error

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -8,7 +8,7 @@ REM Hook scripts use extensionless filenames (e.g. "session-start" not
 REM "session-start.sh") so Claude Code's Windows auto-detection -- which
 REM prepends "bash" to any command containing .sh -- doesn't interfere.
 REM
-REM Usage: run-hook.cmd <script-name> [args...]
+REM Usage: run-hook.cmd <script-name>
 
 if "%~1"=="" (
     echo run-hook.cmd: missing script name >&2
@@ -18,30 +18,24 @@ if "%~1"=="" (
 set "HOOK_DIR=%~dp0"
 set "HOOK_SCRIPT=%~1"
 
-REM Forward every argument after the first, preserving the caller's quoting.
-REM cmd has no "$@" equivalent: %* still includes %1, and shift does not
-REM affect %*, so split %* on its first token and keep the remainder.
-set "HOOK_ARGS="
-for /f "tokens=1,*" %%a in ("%*") do set "HOOK_ARGS=%%b"
-
 REM Bare `exit /b` propagates the real errorlevel. `exit /b %ERRORLEVEL%`
 REM would not: cmd expands %ERRORLEVEL% when it parses the whole
 REM parenthesised block, before any line inside it has run.
 
 REM Try Git for Windows bash in standard locations
 if exist "C:\Program Files\Git\bin\bash.exe" (
-    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%" %HOOK_ARGS%
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%"
     exit /b
 )
 if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
-    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%" %HOOK_ARGS%
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%"
     exit /b
 )
 
 REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
 where bash >nul 2>nul
 if %ERRORLEVEL% equ 0 (
-    bash "%HOOK_DIR%%HOOK_SCRIPT%" %HOOK_ARGS%
+    bash "%HOOK_DIR%%HOOK_SCRIPT%"
     exit /b
 )
 
@@ -59,6 +53,4 @@ if [ $# -eq 0 ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SCRIPT_NAME="$1"
-shift
-exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
+exec bash "${SCRIPT_DIR}/$1"

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,53 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for hook scripts.
+REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
+REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM
+REM Hook scripts use extensionless filenames (e.g. "session-start" not
+REM "session-start.sh") so Claude Code's Windows auto-detection -- which
+REM prepends "bash" to any command containing .sh -- doesn't interfere.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+REM Try Git for Windows bash in standard locations
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found - exit silently rather than error
+REM (plugin still works, just without SessionStart context injection)
+exit /b 0
+CMDBLOCK
+
+# Unix: run the named script directly.
+# The guard mirrors the batch half above; without it an argument-less call
+# execs the hooks directory itself and dies with "Is a directory".
+if [ $# -eq 0 ]; then
+  echo "run-hook.cmd: missing script name" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "type": "module",
   "main": ".opencode/plugins/vibekit.js",
   "scripts": {
-    "check": "npm run check:json && npm run check:versions && npm run check:manifests && npm run check:skills && npm run check:code && npm run check:pack",
+    "check": "npm run check:json && npm run check:versions && npm run check:manifests && npm run check:skills && npm run check:code && npm run check:pack && npm run check:hook",
     "check:json": "node scripts/check-json.mjs",
     "check:versions": "node scripts/check-versions.mjs",
     "check:manifests": "node scripts/check-manifests.mjs",
     "check:skills": "node scripts/check-skills.mjs",
     "check:code": "node scripts/check-code.mjs",
-    "check:pack": "node scripts/check-pack.mjs"
+    "check:pack": "node scripts/check-pack.mjs",
+    "check:hook": "node scripts/check-hook.mjs"
   },
   "license": "MIT",
   "repository": {

--- a/scripts/check-hook.mjs
+++ b/scripts/check-hook.mjs
@@ -1,0 +1,90 @@
+// Smoke-test the SessionStart hook end-to-end on the current platform. This is
+// the one check that must also pass on Windows: the hook IS the integration —
+// when it fails to execute, every skill goes inert with no visible error, which
+// is precisely the failure this check exists to catch.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { report } from "./_util.mjs";
+
+const errors = [];
+const wrapper = join(process.cwd(), "hooks", "run-hook.cmd");
+const direct = join(process.cwd(), "hooks", "session-start");
+
+// On Windows the wrapper is invoked as a .cmd through the shell (the real path
+// a runtime takes); on Unix it is invoked as a bash script.
+const run = (extraEnv = {}) => {
+  const env = { ...process.env, ...extraEnv };
+  return process.platform === "win32"
+    ? spawnSync(wrapper, ["session-start"], { encoding: "utf8", shell: true, env })
+    : spawnSync("bash", [wrapper, "session-start"], { encoding: "utf8", env });
+};
+
+// The hook emits one of three envelope shapes depending on the runtime.
+const contextOf = (o) =>
+  o?.hookSpecificOutput?.additionalContext ?? o?.additionalContext ?? o?.additional_context;
+
+if (!existsSync(wrapper)) {
+  errors.push("hooks/run-hook.cmd does not exist");
+} else {
+  const r = run();
+
+  if (r.status !== 0) {
+    errors.push(`wrapper exited ${r.status} (stderr: ${(r.stderr || "").trim().slice(0, 200)})`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch (e) {
+    errors.push(`stdout is not valid JSON: ${e.message}`);
+  }
+
+  if (parsed) {
+    const ctx = contextOf(parsed);
+    if (typeof ctx !== "string") {
+      errors.push(`no context field in envelope (keys: ${Object.keys(parsed).join(", ")})`);
+    } else {
+      // Assert on payload content, not just parseability. session-start
+      // swallows a failed read and emits the error text AS the context with
+      // exit 0, so a JSON-valid response proves nothing on its own.
+      if (!ctx.includes("You have vibekit")) errors.push("context missing priming header");
+      if (!ctx.includes("Auto-trigger map")) errors.push("context missing using-vibekit skill body");
+      if (/No such file or directory|Error reading/.test(ctx)) {
+        errors.push("context contains a file-read error instead of the skill body");
+      }
+    }
+  }
+
+  // The CLAUDE_PLUGIN_ROOT branch must produce the nested envelope.
+  const nested = run({ CLAUDE_PLUGIN_ROOT: process.cwd(), COPILOT_CLI: "" });
+  try {
+    const n = JSON.parse(nested.stdout);
+    if (!n.hookSpecificOutput?.additionalContext?.includes("You have vibekit")) {
+      errors.push("CLAUDE_PLUGIN_ROOT branch did not produce hookSpecificOutput.additionalContext");
+    }
+  } catch {
+    errors.push("CLAUDE_PLUGIN_ROOT branch did not emit valid JSON");
+  }
+
+  // On Unix the wrapper must be a transparent pass-through. (Skipped on
+  // Windows, where session-start cannot be invoked directly at all — that
+  // being the whole reason the wrapper exists.)
+  if (process.platform !== "win32" && existsSync(direct)) {
+    const d = spawnSync("bash", [direct], { encoding: "utf8" });
+    if (d.stdout !== r.stdout) errors.push("wrapper output differs from direct session-start invocation");
+  }
+
+  // Regression guard: the batch half must stay inert under bash.
+  if (process.platform !== "win32" && (r.stderr || "").trim() !== "") {
+    errors.push(`wrapper emitted stderr under bash: ${r.stderr.trim().slice(0, 200)}`);
+  }
+
+  // Missing-argument guard must fail loudly rather than exec a directory.
+  const bare = process.platform === "win32"
+    ? spawnSync(wrapper, [], { encoding: "utf8", shell: true })
+    : spawnSync("bash", [wrapper], { encoding: "utf8" });
+  if (bare.status !== 1) errors.push(`wrapper with no argument exited ${bare.status}, expected 1`);
+}
+
+report(`SessionStart hook (${process.platform})`, errors);

--- a/scripts/check-hook.mjs
+++ b/scripts/check-hook.mjs
@@ -27,7 +27,9 @@ const contextOf = (o) =>
 if (!existsSync(wrapper)) {
   errors.push("hooks/run-hook.cmd does not exist");
 } else {
-  const r = run();
+  // Hermetic: clear every envelope-selecting variable so the bare shape is
+  // deterministic regardless of what the ambient environment happens to set.
+  const r = run({ CURSOR_PLUGIN_ROOT: "", CLAUDE_PLUGIN_ROOT: "", COPILOT_CLI: "" });
 
   if (r.status !== 0) {
     errors.push(`wrapper exited ${r.status} (stderr: ${(r.stderr || "").trim().slice(0, 200)})`);
@@ -65,6 +67,17 @@ if (!existsSync(wrapper)) {
     }
   } catch {
     errors.push("CLAUDE_PLUGIN_ROOT branch did not emit valid JSON");
+  }
+
+  // The CURSOR_PLUGIN_ROOT branch must produce the flat snake_case envelope.
+  const cursor = run({ CURSOR_PLUGIN_ROOT: process.cwd() });
+  try {
+    const c = JSON.parse(cursor.stdout);
+    if (!c.additional_context?.includes("You have vibekit")) {
+      errors.push("CURSOR_PLUGIN_ROOT branch did not produce additional_context");
+    }
+  } catch {
+    errors.push("CURSOR_PLUGIN_ROOT branch did not emit valid JSON");
   }
 
   // On Unix the wrapper must be a transparent pass-through. (Skipped on

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -9,7 +9,12 @@ import { join } from "node:path";
 import { report } from "./_util.mjs";
 
 const out = execSync("npm pack --dry-run --json", { encoding: "utf8" });
-const shipped = new Set(JSON.parse(out)[0].files.map((f) => f.path));
+// npm >=12 returns an object keyed by package name; earlier versions
+// returned a single-element array. Accept both so the check survives an
+// npm major bump.
+const parsed = JSON.parse(out);
+const meta = Array.isArray(parsed) ? parsed[0] : Object.values(parsed)[0];
+const shipped = new Set(meta.files.map((f) => f.path));
 const errors = [];
 
 // (a) every top-level skill with a SKILL.md must ship.


### PR DESCRIPTION
## Problem

`hooks/hooks.json` registered the SessionStart hook as a direct invocation of `hooks/session-start`, a bash script. On Windows the runtime hands that path to `cmd.exe`, which has no shebang concept, so the hook never executes. The `using-vibekit` priming layer is never injected, every skill sits inert, and **the user sees no error** — vibekit silently does nothing.

This affected two of five runtimes, because both resolve the same file:

| Runtime | Bootstrap | Windows |
|---|---|---|
| Claude Code | `hooks/hooks.json` → `hooks/session-start` | broken |
| Codex | `.codex-plugin/plugin.json` → same `hooks/hooks.json` | broken |
| opencode / Pi / Gemini | node plugin / TS extension / static context file | fine |

## Approach

A polyglot `hooks/run-hook.cmd` that is simultaneously a valid batch script and a valid bash script. Under bash, `:` is a no-op and `<< 'CMDBLOCK'` swallows the batch half as a discarded heredoc; under `cmd.exe`, the batch half locates `bash.exe` and dispatches to the real hook.

`hooks/session-start` is **not modified** — the path that works for every current user is untouched. One edit to `hooks/hooks.json` fixes both affected runtimes.

A Node rewrite of the hook was considered and rejected: Codex ships as a statically-linked native binary and installs vibekit via `codex plugin marketplace add` rather than npm, so a Codex user may have no Node at all. That change would have broken Codex on Linux and macOS to fix Windows.

## Changes

| File | Change |
|---|---|
| `hooks/run-hook.cmd` | new — polyglot wrapper (56 lines) |
| `hooks/hooks.json` | route through the wrapper; add `"shell": "bash"` |
| `scripts/check-hook.mjs` | new — cross-platform end-to-end hook smoke test |
| `package.json` | add `check:hook`, append it to the `check` chain |
| `.github/workflows/ci.yml` | new `hook` job, `[ubuntu-latest, windows-latest]` matrix |
| `scripts/check-pack.mjs` | unrelated pre-existing bug, see below |

### Incidental fix

`scripts/check-pack.mjs` crashed on npm >= 12, which changed `npm pack --dry-run --json` from an array to an object keyed by package name. This broke `npm run check` on `main` and blocked this branch's own verification, so it is fixed here in its own commit (`1a39217`). The fix accepts both shapes and is backward-compatible with npm < 12.

## Verification

`npm run check` exits 0 locally, including the new hook smoke test. The wrapper's output is byte-identical to invoking `hooks/session-start` directly (5309 bytes), and that identity is now a standing assertion in CI on every non-Windows run.

**The Windows path is unproven until this PR's CI runs.** Nothing on a Linux dev box can execute the batch half. The `windows-latest` leg of the `hook` job is the first and only machine-executed evidence that it works — that leg passing is the merge condition for this PR. A local verification pass returned `not ready` for exactly this reason, and that is the intended outcome rather than a defect.

`scripts/check-hook.mjs` asserts on **payload content**, not just exit status: `hooks/session-start` swallows a failed read and emits the error text as the context with exit 0, so a JSON-valid response proves nothing on its own.

## Known limitations

- The wrapper does not remove the bash dependency; it locates bash instead of assuming the OS runs the shebang. Windows users with no bash at all (no Git for Windows, MSYS2, or Cygwin) get no priming — silently, by design, via `exit /b 0` rather than a visible error.
- The pre-existing hand-rolled JSON escaper at `hooks/session-start:12-20` handles five escape sequences and would emit malformed JSON on other control bytes. Out of scope here; worth its own change.
- `AGENTS.md` and `CLAUDE.md` still describe the Cursor branch as dormant scaffolding, but `check-hook.mjs` now actively tests it. Minor documentation drift introduced by this branch.
