### PR TITLE
fix(exec-dispatch): declare the NEEDS_INPUT contract in the brief template

### DIFF
--- a/skills/exec-dispatch/SKILL.md
+++ b/skills/exec-dispatch/SKILL.md
@@ -62,14 +62,21 @@ CONSTRAINTS:
   - Mark any deliberate simplification with a `vibekit:` comment naming its ceiling and upgrade path (see "vibekit: simplification comments").
   - The task header's `→ verify:` clause is the success criterion; the task is not done until that criterion is observably met.
   - If any step fails or produces output that does not match the task's "Expected" value, stop and report the failure. Do not improvise a fix.
+  - You MAY halt with a NEEDS_INPUT return ONLY on spec-ambiguity (a spec/plan detail with two reasonable interpretations) OR missing-context (a file/API/library reference the brief did not provide). You MAY NOT use NEEDS_INPUT for environment, tooling, test, or dependency failures — those are task failures and go in `unexpected`.
+  - A NEEDS_INPUT return MUST include: `blocking_step` (verbatim quote of the plan step you halted at), `tried` (what you attempted to resolve from the brief alone — `n/a` is invalid), 2+ `options` with non-empty `label` and `summary`, and a `recommendation` (option label + reason, or exactly `none — no clear preference`). Vague returns are REJECTED by report-filter.
+  - Before halting with NEEDS_INPUT, roll back any uncommitted partial work (`git restore .`) and any commits made during this task attempt (`git reset --hard <pre-task-sha>`). Set `rolled_back: true` in the return.
+  - Budget cap: at most TWO NEEDS_INPUT signals on the same task across re-dispatches. A third halt is a task failure, not a question.
 CONTEXT:
   Plan path: <path>
   Plan commit SHA: <sha of HEAD for the plan file at dispatch time>
   Task id: Task N
   Instruction: read the plan file at <path> at commit <sha>, locate the section headed `### Task N:`, and follow every step in order. Do not paraphrase the plan; execute it as written.
   Repo state: <branch, worktree, any user-visible constraints>
-OUTPUT (return exactly this JSON schema):
+OUTPUT (discriminated union — return EXACTLY ONE variant):
+
+  Variant A — task complete:
   {
+    "status": "complete",
     "task_number": <int>,
     "task_title": "<string>",
     "files_created": ["<path>"],
@@ -80,6 +87,23 @@ OUTPUT (return exactly this JSON schema):
     ],
     "commits": [{"sha": "<string>", "subject": "<string>"}],
     "unexpected": "<string — anything that deviated from the plan, empty if none>"
+  }
+
+  Variant B — needs input (spec-ambiguity OR missing-context only):
+  {
+    "status": "needs_input",
+    "task_number": <int>,
+    "task_title": "<string>",
+    "blocking_step": "<verbatim plan step quote>",
+    "ambiguity_type": "spec-ambiguity | missing-context",
+    "question": "<string ending with ?>",
+    "tried": "<what you attempted from the brief alone>",
+    "options": [
+      {"label": "A", "summary": "<string>"},
+      {"label": "B", "summary": "<string>"}
+    ],
+    "recommendation": "<option label + reason, or 'none — no clear preference'>",
+    "rolled_back": true
   }
 ```
 


### PR DESCRIPTION
## Problem

`exec-dispatch`'s brief template mentioned `NEEDS_INPUT` **zero** times and declared no `status` field. The same skill carries a 75-line NEEDS_INPUT halt-and-resume protocol that routes returns on that discriminator.

A subagent briefed strictly from that template is never told the halt option exists and has no field to express it in — so it **cannot produce the return the protocol is written to handle**. The protocol was unreachable code.

| | mentions |
|---|---|
| `NEEDS_INPUT` across the skill | 13 |
| `NEEDS_INPUT` in the brief template | **0** |

### Measured

Five fresh agents each invoked `exec-dispatch` via the Skill tool and compiled a dispatch brief for the same task against the same fixture plan. All five produced a well-formed brief carrying every one of the 13 task-specific constraints. **Zero carried the halt contract or declared `status`.**

This was also observed in practice: during two pipeline runs on 2026-07-31, every dispatched brief carried the NEEDS_INPUT constraints only because the operator had read `brief-compiler` directly — not because `exec-dispatch` asked for them. One of those halts caught a defective verify clause in a plan and refused to work around it. Following the template literally, that halt could not have occurred.

## Change

The four NEEDS_INPUT constraint bullets and a Variant A/B discriminated-union OUTPUT schema are declared in `exec-dispatch`'s own brief template. The bullets are byte-identical to `brief-compiler`'s, which remains the canonical definition and which explicitly forbids compressing or paraphrasing that block.

25 insertions, 1 deletion, one file.

## Verification

Static. The defect and the fix are both file-content facts:

- template `NEEDS_INPUT`: 0 → 4; template `"status"`: 0 → 2
- all four bullets appear exactly once here and once in `brief-compiler`
- all 13 pre-existing task-specific constraints intact
- `brief-compiler` and `report-filter` unmodified
- `npm run check` exits 0

## What this PR does not claim

**No valid behavioural measurement was obtained, and the report says so.**

Three eval arms were run and all three are invalid: `Skill(vibekit:exec-dispatch)` loads from the installed plugin cache (`~/.claude/plugins/cache/vibekit/vibekit/0.5.2/`, last modified 2026-07-14), not from the repo worktree where the edits were made. Control, treatment, and alternative-A all measured the same unmodified file and scored 0/5 identically — they agreed because they were the same file.

The control arm survives, because a control arm is *supposed* to measure the unmodified skill. The defect reproduces at 0/5. Both `NOT BINDING` verdicts are withdrawn.

A behavioural change would not be shippable on this basis. A completeness fix to a template is — reading the file settles it.

## Known limitations

- **The duplication that caused the omission remains.** `exec-dispatch` now holds a verbatim copy of `brief-compiler`'s contract. If `brief-compiler` gains a fifth bullet, this copy silently misses it and CI stays green. This buys time, not a cure; a check asserting the two blocks match would close it.
- **An earlier approach — making `exec-dispatch` defer to `brief-compiler` and `report-filter` instead of inlining — was implemented and then reverted on the invalid measurement.** It may work; it was never validly tested. Commits recoverable via reflog.
- **No agent behaviour was measured.** The inference is strong (agents reproduce all 13 template constraints faithfully, so 17 should follow) but it is inference.

## Follow-up this run surfaced

`AGENTS.md` mandates a live eval for orchestration-affecting skill changes, and vibekit documents **no way to run one against edited skills**. Any live eval in this repo silently measures the installed plugin unless the runner knows to sync the cache first. Verifying the delivery *mechanism* is not enough — the *copy* that mechanism serves must be verified too.

## Artifacts

Spec, plan, eval (with its invalidity notice), verification, and review live under `docs/` — gitignored in this repo, so not in the diff.
