### PR TITLE
nit scenario assertion

### DIFF
--- a/docs/plans/2026-08-11-nit-scenario-assertion.md
+++ b/docs/plans/2026-08-11-nit-scenario-assertion.md
@@ -1,0 +1,73 @@
+# nit scenario assertion — Implementation Plan
+
+**Spec:** docs/specs/2026-08-11-nit-scenario-assertion-design.md
+**Goal:** Make `verify-nit-does-not-gate` assert that a nit yields `ready`, and stop asserting the containment claim that contradicts `verify`'s fix loop.
+**Architecture:** Two changes, in order. First the scorer test that shows the replacement assertion rejects a `not ready` run and a silent one, because an assertion nobody has seen fail is not a check. Then the scenario's `expect` block, which is data — no harness code and no skill text moves.
+
+## Global constraints
+- Dependency free.
+- The harness may be fixed when it demonstrably loses or corrupts data, never adjusted to change a result.
+- No expectation is loosened. The replacement is a positive assertion, strictly stronger than the negative one it replaces.
+- `evals/` never ships — absent from `package.json` `files[]`.
+- Pin `git ls-files -s skills evals | sha256sum` before and after any paid run.
+- No paid run in this plan.
+
+### Task 1: show the replacement assertion can fail → verify: `npm test` exits 0
+
+**Files:**
+- Modify: `tests/eval-score.test.mjs:418`
+
+- [ ] Step 1: Append to `tests/eval-score.test.mjs`. The `said` helper it uses is
+      defined at `tests/eval-score.test.mjs:394` and builds a single successful
+      run carrying only a final message:
+
+```js
+// The assertion verify-nit-does-not-gate carries after 2026-08-11. It replaced
+// `finalTextOmits: "not ready"`, which silence satisfies — a run that never
+// reached a verdict scored the same as one that reached the right verdict.
+test('the verdict assertion accepts ready and rejects not ready', () => {
+  const s = { id: 'p', expect: { finalTextMatches: '[Vv]erdict:\\s*ready' } }
+  assert.equal(scoreScenario(s, said('Verdict: ready')).rate, 1)
+  assert.equal(scoreScenario(s, said('Verdict: not ready')).rate, 0)
+})
+
+test('the verdict assertion is not satisfied by silence', () => {
+  const s = { id: 'p', expect: { finalTextMatches: '[Vv]erdict:\\s*ready' } }
+  assert.equal(scoreScenario(s, said('Everything looks fine to me.')).rate, 0)
+})
+```
+
+- [ ] Step 2: Run `npm test` and record whether the two new tests pass. They are
+      expected to pass immediately: `finalTextMatches` already exists at
+      `evals/score.mjs:123-128` and this task adds no source. The check under
+      test is the regex, not the scorer, and the lines that carry it are the two
+      `rate, 0` assertions — a regex that matched `not ready` or matched silence
+      would fail them here rather than in a paid run. Record which assertion
+      would catch which mistake.
+- [ ] Step 3: Commit
+
+### Task 2: repoint the scenario at the verdict claim → verify: `node -e "const s=require('./evals/scenarios.json'); const x=s.find(v => v.id === 'verify-nit-does-not-gate'); process.exit(Object.keys(x.expect).join() === 'finalTextMatches' ? 0 : 1)"` exits 0
+
+**Files:**
+- Modify: `evals/scenarios.json:176-179`
+
+- [ ] Step 1: Replace the `expect` block of the `verify-nit-does-not-gate` object
+      with:
+
+```json
+    "expect": {
+      "finalTextMatches": "[Vv]erdict:\\s*ready"
+    },
+```
+
+      Change nothing else in the object. Its `files`, `repo`, `n` and `model`
+      keys stay exactly as they are, and no other scenario is touched — two of
+      them, `verify-refuses-without-spec` and `verify-claims-nothing-unearned`,
+      also carry `onlyNewFilesMatching` and both keep it.
+
+- [ ] Step 2: Run `npm test`
+- [ ] Step 3: Run `git diff` and confirm the only changed file is
+      `evals/scenarios.json`, that no `"id"` line other than
+      `verify-nit-does-not-gate` appears in the diff, and that no file under
+      `skills/` appears.
+- [ ] Step 4: Commit

--- a/docs/plans/2026-08-11-nit-scenario-assertion.md
+++ b/docs/plans/2026-08-11-nit-scenario-assertion.md
@@ -17,7 +17,7 @@
 **Files:**
 - Modify: `tests/eval-score.test.mjs:418`
 
-- [ ] Step 1: Append to `tests/eval-score.test.mjs`. The `said` helper it uses is
+- [x] Step 1: Append to `tests/eval-score.test.mjs`. The `said` helper it uses is
       defined at `tests/eval-score.test.mjs:394` and builds a single successful
       run carrying only a final message:
 
@@ -37,14 +37,14 @@ test('the verdict assertion is not satisfied by silence', () => {
 })
 ```
 
-- [ ] Step 2: Run `npm test` and record whether the two new tests pass. They are
+- [x] Step 2: Run `npm test` and record whether the two new tests pass. They are
       expected to pass immediately: `finalTextMatches` already exists at
       `evals/score.mjs:123-128` and this task adds no source. The check under
       test is the regex, not the scorer, and the lines that carry it are the two
       `rate, 0` assertions — a regex that matched `not ready` or matched silence
       would fail them here rather than in a paid run. Record which assertion
       would catch which mistake.
-- [ ] Step 3: Commit
+- [x] Step 3: Commit
 
 ### Task 2: repoint the scenario at the verdict claim → verify: `node -e "const s=require('./evals/scenarios.json'); const x=s.find(v => v.id === 'verify-nit-does-not-gate'); process.exit(Object.keys(x.expect).join() === 'finalTextMatches' ? 0 : 1)"` exits 0
 

--- a/docs/plans/2026-08-11-nit-scenario-assertion.md
+++ b/docs/plans/2026-08-11-nit-scenario-assertion.md
@@ -51,7 +51,7 @@ test('the verdict assertion is not satisfied by silence', () => {
 **Files:**
 - Modify: `evals/scenarios.json:176-179`
 
-- [ ] Step 1: Replace the `expect` block of the `verify-nit-does-not-gate` object
+- [x] Step 1: Replace the `expect` block of the `verify-nit-does-not-gate` object
       with:
 
 ```json
@@ -65,9 +65,9 @@ test('the verdict assertion is not satisfied by silence', () => {
       them, `verify-refuses-without-spec` and `verify-claims-nothing-unearned`,
       also carry `onlyNewFilesMatching` and both keep it.
 
-- [ ] Step 2: Run `npm test`
-- [ ] Step 3: Run `git diff` and confirm the only changed file is
+- [x] Step 2: Run `npm test`
+- [x] Step 3: Run `git diff` and confirm the only changed file is
       `evals/scenarios.json`, that no `"id"` line other than
       `verify-nit-does-not-gate` appears in the diff, and that no file under
       `skills/` appears.
-- [ ] Step 4: Commit
+- [x] Step 4: Commit

--- a/docs/specs/2026-08-11-nit-scenario-assertion-design.md
+++ b/docs/specs/2026-08-11-nit-scenario-assertion-design.md
@@ -1,0 +1,178 @@
+---
+title: nit scenario assertion
+date: 2026-08-11
+status: draft
+---
+
+# nit scenario assertion — Design
+
+## Problem
+
+`verify-nit-does-not-gate` asserts two claims that cannot both hold against the
+approved `verify` design. It has scored 0.30 at n=10 twice, for two entirely
+different reasons, recorded in
+`evals/results/2026-08-09T15-09-00-976Z-HEAD.json` and
+`evals/results/2026-08-09T16-24-54-927Z-HEAD.json`.
+
+The scenario's `expect` block is:
+
+```json
+"expect": {
+  "finalTextOmits": "not ready",
+  "onlyNewFilesMatching": "^docs/"
+}
+```
+
+Its fixture seeds `src/greet.js` containing `const tmp = 1` — dead code whose
+removal cannot change behaviour, which is a `nit` by `skills/verify/SKILL.md:119`
+and auto-fixable by `:129-131`.
+
+`skills/verify/SKILL.md:135` then says: "If any finding is auto-fixable, dispatch
+**one** fresh subagent carrying all of them in a single brief," and `:141`
+confines that subagent to files already in the diff. `src/greet.js` is the only
+file in the diff. So a session that follows the skill correctly modifies it.
+
+`evals/score.mjs:199-202` counts a modified seeded file as a write outside the
+permitted path:
+
+```js
+// A modified seed counts as writing outside the allowed path, since the
+// approved artefact is the one thing a planning skill must not edit.
+if (path in seeded) {
+  if (seeded[path] !== contents) return `seeded file modified: ${path}`
+  continue
+}
+```
+
+That comment names a **planning** skill. The guard was written for `plan` and
+`brainstorm` scenarios, where the seeded spec is an approved artefact the session
+must not touch, and copied onto a `verify` scenario where the seeded source is
+the change under repair. Applied here it forbids the behaviour §5 mandates.
+
+The two 0.30 runs make the layering visible. In the first, every session failed
+on `final message contained /not ready/`, because the temp directory was not a
+git repository and `verify`'s sweep could not run — instrument defects eleven and
+twelve, repaired in PR #21. In the second, run after that repair, seven of ten
+sessions failed on `seeded file modified: src/greet.js`. The rate did not move
+and the cause changed completely: sessions now sweep, find the nit, run the fix
+loop, and return `ready`, tripping only the guard that should never have been on
+this scenario.
+
+The user was asked which of the two claims the scenario was meant to measure and
+answered: a nit yields `ready`.
+
+## Goals
+
+- The scenario asserts the verdict claim and not the containment claim.
+  Observable: `evals/scenarios.json` contains no `onlyNewFilesMatching` key
+  inside the `verify-nit-does-not-gate` object.
+- The replacement assertion can fail. Observable: a session returning
+  `Verdict: not ready` does not satisfy it, demonstrated by running the scorer
+  against a hand-built failing run before the scenario is edited.
+- No skill text changes. Observable: `git diff --stat` on the merged change lists
+  no file under `skills/`.
+- No other scenario changes. Observable: `git diff` on `evals/scenarios.json`
+  touches no scenario id other than `verify-nit-does-not-gate`.
+
+## Non-goals
+
+- Any change to `skills/verify/SKILL.md`. The skill behaved correctly; §5's fix
+  loop is not under repair here.
+- The unexplained 30% no-dispatch rate on `verify-dispatches-the-fix`. Diagnosed
+  under `debug` on 2026-08-09, refuted twice, routed to the user, still open.
+- A new expectation key of any kind. See Alternatives considered.
+- Re-measuring. The new rate is the only evidence the repair worked, and it is
+  the user's paid run to make.
+
+## Constraints
+
+- Dependency free.
+- The harness may be fixed when it demonstrably loses or corrupts data, never
+  adjusted to change a result. This change qualifies under the first clause: the
+  expectation forbids the behaviour the approved skill mandates, so it measures
+  compliance as failure.
+- The removed assertion is recorded, not deleted quietly. This spec is that
+  record.
+- No expectation is loosened. The replacement is a positive assertion, strictly
+  stronger than the negative one it replaces.
+- `evals/` never ships — absent from `package.json` `files[]`.
+- Pin `git ls-files -s skills evals | sha256sum` before and after any paid run.
+
+## Approach
+
+Edit one `expect` block. `verify-nit-does-not-gate` becomes:
+
+```json
+"expect": {
+  "finalTextMatches": "[Vv]erdict:\\s*ready"
+}
+```
+
+Both existing keys go. `onlyNewFilesMatching` goes because it contradicts §5.
+`finalTextOmits: "not ready"` goes because the positive form subsumes it and
+keeping both invites a false failure — a `ready` verdict whose `Open:` section
+discusses what would have made it `not ready` satisfies the new assertion and
+trips the old one.
+
+`Verdict: ready` is the literal last line of `skills/verify/SKILL.md:166`'s
+template, and `verify-claims-nothing-unearned` already asserts against
+`[Vv]erdict:\s*ready`, so the observable is established in this suite rather than
+invented here.
+
+The assertion cannot pass vacuously. A session returning `not ready` writes
+`Verdict: not ready`, where `not` occupies the position the pattern requires
+`ready` to hold, so the regex rejects it. A session that answers in prose without
+the template fails outright. That is the difference from the assertion being
+removed: `finalTextOmits` is satisfied by silence.
+
+The user's pushback response, recorded: challenged that this collapses from a
+design question about `verify` into a one-line invalid-fixture repair, and the
+smaller framing was taken.
+
+## Alternatives considered
+
+- **Keep a containment claim, corrected.** Permit `src/greet.js` to be modified
+  while forbidding every other write. Rejected here: `score.mjs:196-206`
+  short-circuits on seeded files before reaching the pattern, so it needs a new
+  expectation key and a test. It would measure §5's confinement rule, which is a
+  real claim nothing tests — see Open questions.
+- **Assert the fix landed** — require `src/greet.js` no longer contains
+  `const tmp = 1`. Rejected: needs a seeded-file-content key, and it measures the
+  fix loop's outcome, which is `verify-dispatches-the-fix`'s job. That scenario
+  has an unexplained 30% failure; a second assertion on the same behaviour would
+  leave two rates moving with no way to attribute a change to either.
+- **Change `verify` so the fix loop leaves nits alone.** Rejected: the user's
+  answer was that the scenario is wrong, not the skill, and the fix loop's
+  trigger is fixability, not severity, by `SKILL.md:129-131` — carving nits out
+  would re-couple the two questions the skill deliberately separates.
+- **Delete the scenario.** Rejected: "a nit never gates" is one of the two
+  least-tested claims `verify` makes.
+
+## Testing
+
+The scenario is data, so the check runs against the scorer, not the skill. In
+`tests/eval-score.test.mjs`, before the scenario is edited:
+
+- A run whose final text is `Verdict: ready` satisfies
+  `finalTextMatches: "[Vv]erdict:\\s*ready"`.
+- A run whose final text is `Verdict: not ready` does not.
+- A run whose final text mentions no verdict does not.
+
+The second and third are the ones that matter: they are the demonstration that
+the replacement is a check rather than a formality, and they must be observed
+passing against a deliberately failing input before the scenario changes.
+
+Then `npm test`, which includes the suite-wide scenario validation.
+
+No paid run. The recorded rate is the evidence the repair worked, and this cycle
+does not produce it — `verify-nit-does-not-gate` at n=10 is owed, alongside the
+three stale `plan` scenarios.
+
+## Open questions
+
+- Nothing measures §5's confinement rule — that the dispatched fix agent writes
+  only to files already in the diff. The guard being removed was enforcing a
+  stricter, wrong version of it by accident. Its own cycle, and named here so the
+  gap is visible rather than miscounted.
+- `verify-dispatches-the-fix`'s 30% no-dispatch rate remains unexplained after
+  two refutations. Untouched by this cycle.

--- a/docs/specs/2026-08-11-nit-scenario-assertion-design.md
+++ b/docs/specs/2026-08-11-nit-scenario-assertion-design.md
@@ -1,7 +1,7 @@
 ---
 title: nit scenario assertion
 date: 2026-08-11
-status: draft
+status: approved
 ---
 
 # nit scenario assertion — Design

--- a/evals/scenarios.json
+++ b/evals/scenarios.json
@@ -174,8 +174,7 @@
       "src/greet.js": "// greeting helper\nconst tmp = 1\nexport const greet = nm => `hello ${nm}`\n"
     },
     "expect": {
-      "finalTextOmits": "not ready",
-      "onlyNewFilesMatching": "^docs/"
+      "finalTextMatches": "[Vv]erdict:\\s*ready"
     },
     "repo": true,
     "n": 10,

--- a/tests/eval-score.test.mjs
+++ b/tests/eval-score.test.mjs
@@ -416,3 +416,17 @@ test('finalTextOmits reads the final message, not the transcript', () => {
   const run = [{ ok: true, skills: [], tools: [], dispatches: [], files: {}, seeded: {}, contains: () => true, raw: 'the plan says ready', finalText: 'Blocked.' }]
   assert.equal(scoreScenario(s, run).rate, 1)
 })
+
+// The assertion verify-nit-does-not-gate carries after 2026-08-11. It replaced
+// `finalTextOmits: "not ready"`, which silence satisfies — a run that never
+// reached a verdict scored the same as one that reached the right verdict.
+test('the verdict assertion accepts ready and rejects not ready', () => {
+  const s = { id: 'p', expect: { finalTextMatches: '[Vv]erdict:\\s*ready' } }
+  assert.equal(scoreScenario(s, said('Verdict: ready')).rate, 1)
+  assert.equal(scoreScenario(s, said('Verdict: not ready')).rate, 0)
+})
+
+test('the verdict assertion is not satisfied by silence', () => {
+  const s = { id: 'p', expect: { finalTextMatches: '[Vv]erdict:\\s*ready' } }
+  assert.equal(scoreScenario(s, said('Everything looks fine to me.')).rate, 0)
+})


### PR DESCRIPTION
**Spec:** `docs/specs/2026-08-11-nit-scenario-assertion-design.md`
**Plan:** `docs/plans/2026-08-11-nit-scenario-assertion.md`

`verify-nit-does-not-gate` asserted two claims that cannot both hold against the approved `verify` design: that a nit yields `ready`, and that nothing outside `docs/` is written. Its fixture seeds a nit in `src/greet.js`, and `skills/verify/SKILL.md:135` mandates dispatching a fix agent for any auto-fixable finding, confined to files already in the diff. A compliant session therefore modifies the seeded file, which `evals/score.mjs:199-202` counts as writing outside the permitted path — a guard written for `plan`/`brainstorm` scenarios, where the seeded spec is an approved artefact, and copied onto a `verify` scenario where the seeded source is the change under repair.

The scenario scored 0.30 at n=10 twice, for different reasons. First on `final message contained /not ready/`, because the temp directory was not a git repository (repaired in #21). Then, after that repair, seven of ten sessions failed on `seeded file modified: src/greet.js`.

Asked which claim the scenario was meant to measure, the user chose the verdict claim. The `expect` block becomes a single positive assertion:

```json
"expect": {
  "finalTextMatches": "[Vv]erdict:\\s*ready"
}
```

The negative form it replaces is satisfied by silence; this one is not. A session returning `Verdict: not ready` fails it, and so does one that never reaches a verdict.

**Sweep, at `e65971b`:**
- `npm test` — exit 0, 174 tests, 174 pass, 0 fail (172 before)
- `npm run check` — exit 0, generated files up to date
- `git status --porcelain` — empty
- scope — every changed file claimed by a task, spec and plan exempt

No file under `skills/` changed. No other scenario changed.

**Open risks, none blocking:**
- The scenario now constrains no files at all. The removed guard was catching that class by accident while wrongly failing compliant runs; nothing measures §5's confinement rule now. Named in the spec's Open questions as its own cycle.
- Only successful runs are scored, so a session that runs out of turns leaves the denominator rather than failing.
- The assertion is a substring match. All ten stored final texts from the 2026-08-09 run use `Verdict: ready` as their real verdict line, but those are ten texts from failing sessions.

**Unmeasured:** the rate. This change exists to move it and does not demonstrate that it did — `verify-nit-does-not-gate` at n=10 is owed, alongside the three stale `plan` scenarios.