### PR TITLE
version 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "vibekit",
       "description": "Guardrailed vibe-coding pipeline for coding agents.",
-      "version": "2.0.0",
+      "version": "0.6.0",
       "source": "./",
       "author": {
         "name": "rizukirr",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vibekit",
   "description": "Guardrailed vibe-coding pipeline for coding agents.",
-  "version": "2.0.0",
+  "version": "0.6.0",
   "author": {
     "name": "rizukirr",
     "url": "https://github.com/rizukirr"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibekit",
-  "version": "2.0.0",
+  "version": "0.6.0",
   "description": "Guardrailed vibe-coding pipeline for coding agents.",
   "author": {
     "name": "rizukirr",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Guardrailed vibe-coding pipeline for coding agents. Dependency free.
 | Runtime | Emitter | Verified |
 |---|---|---|
 | Claude Code | `runtimes/claude-code.mjs` | Yes — SessionStart hook smoke-tested in CI on Linux and Windows |
-| Codex | `runtimes/codex.mjs` | installed from this checkout and listed as enabled at version 2.0.0 by `codex plugin list`, against codex-cli 0.147.0 |
+| Codex | `runtimes/codex.mjs` | installed from this checkout and listed as enabled at version 0.6.0 by `codex plugin list`, against codex-cli 0.147.0 |
 | opencode | `runtimes/opencode.mjs` | all ten skills listed by `opencode debug skill`, against opencode 1.18.16 |
 | Gemini | `runtimes/gemini.mjs` | not verified — tool not installed |
 | Pi | `runtimes/pi.mjs` | not verified — tool not installed |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "vibekit",
   "description": "Guardrailed vibe-coding pipeline for coding agents.",
-  "version": "2.0.0",
+  "version": "0.6.0",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rizukirr/vibekit",
-  "version": "2.0.0",
+  "version": "0.6.0",
   "description": "Guardrailed vibe-coding pipeline for coding agents.",
   "type": "module",
   "license": "MIT",

--- a/tests/claude-code.test.mjs
+++ b/tests/claude-code.test.mjs
@@ -7,7 +7,7 @@ import { MODEL } from './helpers.mjs'
 test('emits the plugin manifest stamped with the config version', () => {
   const plugin = JSON.parse(emit(MODEL)['.claude-plugin/plugin.json'])
   assert.equal(plugin.name, 'vibekit')
-  assert.equal(plugin.version, '2.0.0')
+  assert.equal(plugin.version, '0.6.0')
   assert.equal(plugin.license, 'MIT')
 })
 

--- a/tests/codex.test.mjs
+++ b/tests/codex.test.mjs
@@ -10,7 +10,7 @@ test('is identified as codex', () => {
 
 test('emits a plugin manifest pointing at the shared skills directory', () => {
   const plugin = JSON.parse(emit(MODEL)['.codex-plugin/plugin.json'])
-  assert.equal(plugin.version, '2.0.0')
+  assert.equal(plugin.version, '0.6.0')
   assert.equal(plugin.skills, './skills/')
   assert.equal(plugin.hooks, './hooks/hooks.json')
 })

--- a/tests/core.test.mjs
+++ b/tests/core.test.mjs
@@ -11,7 +11,7 @@ test('is identified as core', () => {
 test('composes package.json from the config npm block plus generated fields', () => {
   const pkg = JSON.parse(emit(MODEL)['package.json'])
   assert.equal(pkg.name, '@rizukirr/vibekit')
-  assert.equal(pkg.version, '2.0.0')
+  assert.equal(pkg.version, '0.6.0')
   assert.equal(pkg.type, 'module')
   assert.equal(pkg.license, 'MIT')
   assert.deepEqual(pkg.publishConfig, { access: 'public' })

--- a/tests/gemini.test.mjs
+++ b/tests/gemini.test.mjs
@@ -12,7 +12,7 @@ test('emits an extension manifest pointing at the context file', () => {
   const manifest = JSON.parse(emit(MODEL)['gemini-extension.json'])
   assert.equal(manifest.name, 'vibekit')
   assert.equal(manifest.contextFileName, 'GEMINI.md')
-  assert.equal(manifest.version, '2.0.0')
+  assert.equal(manifest.version, '0.6.0')
 })
 
 test('claims the context file as a generated region', () => {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -22,7 +22,7 @@ export function skillFile({ name, description = 'does a thing', trigger = 'when 
 export const MODEL = {
   config: {
     name: 'vibekit',
-    version: '2.0.0',
+    version: '0.6.0',
     description: 'Guardrailed vibe-coding pipeline for coding agents.',
     author: { name: 'rizukirr', url: 'https://github.com/rizukirr' },
     license: 'MIT',

--- a/vibekit.config.json
+++ b/vibekit.config.json
@@ -1,6 +1,6 @@
 {
   "name": "vibekit",
-  "version": "2.0.0",
+  "version": "0.6.0",
   "description": "Guardrailed vibe-coding pipeline for coding agents.",
   "author": { "name": "rizukirr", "url": "https://github.com/rizukirr" },
   "license": "MIT",


### PR DESCRIPTION
v2 carried `2.0.0`, which was never released — npm has `0.5.1` and `0.5.2`, and tags stop at `v0.5.2`. `0.6.0` is the successor to what actually shipped.

`vibekit.config.json` is the single source; `npm run generate` rewrote `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json` and `gemini-extension.json`. Five test assertions and the `MODEL` fixture in `tests/helpers.mjs` pinned the old value and were updated with it.

`README.md:25` was not a config value — it records what `codex plugin list` returned during the PR #23 probe. Rather than rewriting an observation, Codex was reinstalled and the new output recorded:

```
vibekit@vibekit  installed, enabled  0.6.0    /home/rizukirr/Projects/vibekit
```

**Checks:**
- `npm test` — exit 0, 193 tests, 193 pass, 0 fail
- `npm run check` — exit 0
- `git grep 2\.0\.0` outside `docs/` — no matches
- opencode re-probed after the change: `opencode debug skill` still lists all ten skills plus the built-in

`docs/` keeps `2.0.0` where earlier specs and plans quote probe output from the day they were written; those are records, not configuration.