### PR TITLE
terse shaping rules

### DIFF
--- a/docs/plans/2026-08-12-terse-shaping-rules.md
+++ b/docs/plans/2026-08-12-terse-shaping-rules.md
@@ -18,7 +18,7 @@
 - Create: `tests/terse.test.mjs`
 - Modify: `skills/terse/SKILL.md:57`
 
-- [ ] Step 1: Recover the text rather than retyping it. Run
+- [x] Step 1: Recover the text rather than retyping it. Run
       `git show 603b487:skills/terse/SKILL.md` and take the block that begins
       with the line `## Shaping` and ends with the line immediately before
       `### Tells`. That block is rules 1 to 5. Then take the block that begins
@@ -27,7 +27,7 @@
       order, are the text to insert. The `### Tells` subsection between them is
       dropped and must not appear.
 
-- [ ] Step 2: Write `tests/terse.test.mjs`, and observe every test failing
+- [x] Step 2: Write `tests/terse.test.mjs`, and observe every test failing
       before Step 4:
 
 ```js
@@ -74,20 +74,20 @@ test('pins the frontmatter that drives firing', () => {
 })
 ```
 
-- [ ] Step 3: Run `npm test` and record which tests fail and with what messages.
+- [x] Step 3: Run `npm test` and record which tests fail and with what messages.
       A test that passes before the section is written is not a check. The
       frontmatter test is expected to pass from the start, since it pins values
       that already hold; say so rather than claiming it as evidence.
-- [ ] Step 4: Insert the recovered text into `skills/terse/SKILL.md` between the
+- [x] Step 4: Insert the recovered text into `skills/terse/SKILL.md` between the
       line `Resume afterwards.` and the `## What does not save tokens` heading.
       Change no existing line, and add nothing that was not in the two recovered
       blocks.
-- [ ] Step 5: Run `npm test`
-- [ ] Step 6: Run `npm run check` and confirm it exits 0. Then run
+- [x] Step 5: Run `npm test`
+- [x] Step 6: Run `npm run check` and confirm it exits 0. Then run
       `git diff skills/terse/SKILL.md` and confirm no line above `# terse`
       appears in the diff, and `git diff --name-only` and confirm the only paths
       are `skills/terse/SKILL.md` and `tests/terse.test.mjs`.
-- [ ] Step 7: Run `grep -c '—' skills/terse/SKILL.md` and record the count. The
+- [x] Step 7: Run `grep -c '—' skills/terse/SKILL.md` and record the count. The
       recovered text contains em dashes and that is expected: the tells are what
       this cycle drops, not the punctuation of the prose carrying the rules.
-- [ ] Step 8: Commit
+- [x] Step 8: Commit

--- a/docs/plans/2026-08-12-terse-shaping-rules.md
+++ b/docs/plans/2026-08-12-terse-shaping-rules.md
@@ -1,0 +1,93 @@
+# terse shaping rules — Implementation Plan
+
+**Spec:** docs/specs/2026-08-12-terse-shaping-rules-design.md
+**Goal:** Give `terse` the five shaping rules and their exemption, recovered verbatim from commit `603b487`, without the tells that measured inert twice.
+**Architecture:** One insertion into `skills/terse/SKILL.md` between the auto-clarity override and the token section, guarded by four prose tests. Frontmatter is untouched, so firing cannot move. No emitter, harness or scenario changes, and no paid run.
+
+## Global constraints
+- Dependency free.
+- No shipped file under `skills/`, and none of the generated context files, may name a project vibekit borrows from.
+- The never-compress list is not weakened.
+- `terse`'s frontmatter is byte-identical after this change.
+- The tells stay out. They measured inert at n=10 twice.
+- No paid eval run.
+
+### Task 1: the shaping rules → verify: `npm test` exits 0
+
+**Files:**
+- Create: `tests/terse.test.mjs`
+- Modify: `skills/terse/SKILL.md:57`
+
+- [ ] Step 1: Recover the text rather than retyping it. Run
+      `git show 603b487:skills/terse/SKILL.md` and take the block that begins
+      with the line `## Shaping` and ends with the line immediately before
+      `### Tells`. That block is rules 1 to 5. Then take the block that begins
+      `### The exemption` and ends with the line before
+      `## What does not save tokens`. Those two blocks, concatenated in that
+      order, are the text to insert. The `### Tells` subsection between them is
+      dropped and must not appear.
+
+- [ ] Step 2: Write `tests/terse.test.mjs`, and observe every test failing
+      before Step 4:
+
+```js
+// tests/terse.test.mjs
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const terse = readFileSync('skills/terse/SKILL.md', 'utf8')
+
+test('states every shaping rule', () => {
+  for (const phrase of [
+    'Lead with the action',
+    'Restate position',
+    'One concrete next action',
+    'Cap narration lists',
+    'Pre-send deletion pass',
+  ]) {
+    assert.match(terse, new RegExp(phrase, 'i'), `${phrase} missing`)
+  }
+})
+
+// Without the exemption the cap becomes a licence to drop the sixth blocker.
+test('subordinates the cap and the deletion pass to the never-compress list', () => {
+  const section = terse.slice(terse.search(/##\s+Shaping/i))
+  assert.match(section, /never[- ]compress/i, 'the exemption must name the never-compress list')
+  assert.match(section, /narration/i, 'the exemption must scope the rules to narration')
+})
+
+// The tells measured 0.00 against a 0.00 baseline at n=10, in two positions,
+// on 2026-08-11. This test is what stops them returning unnoticed.
+test('omits the tells that measured inert', () => {
+  assert.doesNotMatch(terse, /No em dash/i)
+})
+
+// description and trigger are what the runtime shows the model before it decides
+// to invoke a skill, and trigger feeds three generated tables. Changing either
+// changes firing, which five scenarios measure. Pinned by value rather than by
+// diff against HEAD: a diff against HEAD passes trivially once committed.
+test('pins the frontmatter that drives firing', () => {
+  assert.match(terse, /^trigger: First response of the session — invoke once, then it stays on$/m)
+  assert.match(terse, /^gate: none$/m)
+  assert.match(terse, /^description: Use at the start of every session — compress narration, never artifacts\./m)
+})
+```
+
+- [ ] Step 3: Run `npm test` and record which tests fail and with what messages.
+      A test that passes before the section is written is not a check. The
+      frontmatter test is expected to pass from the start, since it pins values
+      that already hold; say so rather than claiming it as evidence.
+- [ ] Step 4: Insert the recovered text into `skills/terse/SKILL.md` between the
+      line `Resume afterwards.` and the `## What does not save tokens` heading.
+      Change no existing line, and add nothing that was not in the two recovered
+      blocks.
+- [ ] Step 5: Run `npm test`
+- [ ] Step 6: Run `npm run check` and confirm it exits 0. Then run
+      `git diff skills/terse/SKILL.md` and confirm no line above `# terse`
+      appears in the diff, and `git diff --name-only` and confirm the only paths
+      are `skills/terse/SKILL.md` and `tests/terse.test.mjs`.
+- [ ] Step 7: Run `grep -c '—' skills/terse/SKILL.md` and record the count. The
+      recovered text contains em dashes and that is expected: the tells are what
+      this cycle drops, not the punctuation of the prose carrying the rules.
+- [ ] Step 8: Commit

--- a/docs/specs/2026-08-12-terse-shaping-rules-design.md
+++ b/docs/specs/2026-08-12-terse-shaping-rules-design.md
@@ -1,7 +1,7 @@
 ---
 title: terse shaping rules
 date: 2026-08-12
-status: draft
+status: approved
 ---
 
 # terse shaping rules — Design

--- a/docs/specs/2026-08-12-terse-shaping-rules-design.md
+++ b/docs/specs/2026-08-12-terse-shaping-rules-design.md
@@ -1,0 +1,157 @@
+---
+title: terse shaping rules
+date: 2026-08-12
+status: draft
+---
+
+# terse shaping rules — Design
+
+## Problem
+
+`terse` says what to cut. It says nothing about the order what survives arrives
+in, or where the reader is in a multi-step run.
+
+Observed in the session that produced this spec: an eight-task `exec` run
+reported each task's outcome without once stating which task of eight had
+finished. The reader had to count. `terse` was active throughout and forbids
+none of that, because every rule it carries is about deletion.
+
+Two reference projects under `external/` were read for ideas. One shapes output
+for a reader who cannot hold state between turns. The other removes constructions
+that mark prose as machine-written. Their ideas are used here; no shipped file
+names them, and `tests/no-external-references.test.mjs` enforces that.
+
+**Round 1 and round 2 already tried this and failed, and the failure was
+misattributed.** On 2026-08-11 a section carrying both halves went into `terse`,
+measured 0.00 against a 0.00 baseline, and was reverted. It was then moved to the
+top of the file, measured 0.00 again, and reverted again. Recorded in
+`evals/results/2026-08-11T15-18-28-057Z-HEAD.json` and
+`evals/results/2026-08-11T16-09-14-732Z-HEAD.json`.
+
+The scenario behind both numbers is `terse-omits-em-dash`. It tests one tell. It
+never tested a single shaping rule, which the round 1 spec said in advance:
+restating position needs a multi-turn fixture, leading with the action has no
+assertion that survives legitimate variation, and the deletion pass leaves no
+trace. Both reverts therefore discarded an untested component because a tested
+component alongside it failed.
+
+The two halves are in different evidential positions, and this spec separates
+them.
+
+## Goals
+
+- `terse` states the five shaping rules. Observable: `skills/terse/SKILL.md`
+  contains a section naming all of leading with the action, restating position,
+  one next action, the list cap and the pre-send deletion pass.
+- The rules cannot truncate evidence. Observable: `npm test` passes a test
+  asserting the section names the exemption, tying the cap and the deletion pass
+  to the never-compress list.
+- The measured-dead tells stay out. Observable: `skills/terse/SKILL.md` contains
+  no line matching `No em dash`.
+- Firing is untouched. Observable: `git diff` on `skills/terse/SKILL.md` changes
+  no line above the `# terse` heading, so frontmatter is byte-identical.
+- No other skill changes. Observable: `git diff --name-only` lists no file under
+  `skills/` other than `skills/terse/SKILL.md`.
+
+## Non-goals
+
+- The tells. No em dash, no throat-clearing opener, no emphasis adverb, no
+  `not X, it's Y` contrast. Measured inert at n=10 twice, in two positions. A
+  third statement produces the same number. Their absence here is a finding
+  being respected, not an oversight.
+- A new skill. `terse` already owns how the agent talks, and the one measurement
+  on modifier surface reads zero of five for an un-invoked one.
+- A paid run. Nothing here is measurable with the current harness. See Testing.
+- Rewriting vibekit's own skill prose to obey these rules. A separate question,
+  considered and set aside during design.
+- Any change to another skill's text, or to `terse`'s frontmatter.
+
+## Constraints
+
+- Dependency free.
+- No shipped file under `skills/`, and none of the generated context files, may
+  name a project vibekit borrows from.
+- The never-compress list is not weakened. Every rule added here is subordinate
+  to it.
+- `terse`'s frontmatter is byte-identical after this change. `description` and
+  `trigger` are what the runtime shows the model before it decides to invoke a
+  skill, and `lib/model.mjs` feeds `trigger` into three generated trigger tables.
+  Touching either changes firing, which five scenarios measure.
+- Rates are quoted at n=10 or not at all.
+
+## Approach
+
+One section in `skills/terse/SKILL.md`, after `### Auto-clarity override` and
+before `## What does not save tokens`, carrying the five shaping rules and the
+exemption. The text is recovered from commit `603b487` rather than rewritten, so
+it is the same text that was drafted, reviewed and approved on 2026-08-11, minus
+the `### Tells` subsection.
+
+1. **Lead with the action.** If the answer is a command, a path or a snippet, it
+   is the first line.
+2. **Restate position every turn.** In a multi-step run, say where you are.
+3. **One concrete next action** whenever something is left open.
+4. **Cap narration lists at five.**
+5. **Pre-send deletion pass.** Announcements, recaps, sidebars, empty hedges.
+
+### The exemption
+
+The cap and the deletion pass govern narration only. Neither touches anything on
+the never-compress list: a findings list, a blocker enumeration, a goals walk, a
+question to the user, quoted evidence, a destructive-operation warning.
+
+A cap that can truncate findings is a licence to drop the sixth blocker, which is
+the worst thing this pipeline could ship. The exemption is a goal with its own
+test rather than a sentence trusted to be read.
+
+### Position
+
+The section goes back where round 1 put it, not where round 2 put it. Round 2
+tested whether position mattered and measured no difference, so position is a
+free variable and the file reads better with the compress and never-compress
+boundary established first.
+
+## Alternatives considered
+
+- **Include the tells.** Rejected: measured inert at n=10 twice.
+- **A separate skill for output shaping.** Rejected: a third modifier to invoke,
+  against a measurement that says an un-invoked modifier fires zero times in five.
+- **Two new skills mirroring the references.** Rejected for the same reason, and
+  because half their content is the measured-dead half.
+- **Rewrite vibekit's own 1,050 lines of skill prose to obey these rules.** A
+  real option with a testable mechanism — imitation rather than instruction — and
+  a real risk, since it edits the text of nine hard gates in service of a style
+  theory. Set aside, not refuted.
+
+## Testing
+
+Unit, each assertion shown failing before the section is written:
+
+- `skills/terse/SKILL.md` names all five shaping rules.
+- It names the exemption, tying the cap and the deletion pass to the
+  never-compress list.
+- It contains no line matching `No em dash`, so the measured-dead half cannot
+  return unnoticed.
+- `terse`'s frontmatter is unchanged: the first six lines of the file are
+  byte-identical to the previous commit's.
+
+**No paid run, and no rate is claimed.** Three of the five rules cannot be
+measured by the current harness: restating position needs a multi-turn fixture
+and eval sessions are single turn; leading with the action has no assertion that
+survives legitimate variation between a path, a command and a verdict block; the
+deletion pass leaves no trace of what it removed. The remaining two are not worth
+a run on their own.
+
+This ships on judgment. Saying so is the point: the alternative is inventing a
+scenario that passes vacuously and calling it evidence.
+
+## Open questions
+
+- Whether any of the five rules bind. Unknown and, with this harness, unknowable.
+  A multi-turn fixture would make `restate position` measurable, and that is the
+  single most valuable addition the eval harness could gain.
+- Whether the rules that cannot be measured should ship at all. This spec says
+  yes, on the grounds that structure is what every working skill in this repo is
+  made of, and that the pipeline demonstrably follows structural instruction. The
+  contrary view is that two nulls in one day argue for spending nothing further
+  on output shaping.

--- a/skills/terse/SKILL.md
+++ b/skills/terse/SKILL.md
@@ -55,6 +55,35 @@ Drop compression entirely for:
 
 Resume afterwards.
 
+## Shaping
+
+Compression decides what survives. This decides the order it arrives in.
+
+1. **Lead with the action.** If the answer is a command, a path or a snippet, it
+   is the first line. Prose comes after, if at all.
+2. **Restate position every turn.** In a multi-step run, say where you are:
+   `Task 3 of 8 done: opencode emitter. Next: probe it.` The reader is not
+   holding the plan in their head, and a run that reports results without
+   position makes them count.
+3. **One concrete next action** whenever something is left open, small enough to
+   start immediately. "Open the file" counts.
+4. **Cap narration lists at five.** Past five, split into now and later, or must
+   and nice to have. Five ranked beats ten unranked.
+5. **Pre-send deletion pass.** Delete the first sentence if it announces what you
+   are about to do, the last if it recaps or asks whether anything else is
+   needed, any sidebar, and any hedging adverb carrying no real uncertainty. Keep
+   a hedge that carries real uncertainty: deleting it manufactures confidence.
+
+### The exemption
+
+Rule 4 and rule 5 govern **narration only**. Neither touches anything on the
+never-compress list: a findings list, a blocker enumeration, a goals walk, a
+question to the user, quoted evidence, a destructive-operation warning.
+
+A cap that can truncate findings is a licence to drop the sixth blocker. The
+rules above shorten what you say about the work; they never shorten the work's
+own output.
+
 ## What does not save tokens
 
 Measured, not assumed. Do not do these — they cost clarity and save nothing:

--- a/tests/terse.test.mjs
+++ b/tests/terse.test.mjs
@@ -1,0 +1,41 @@
+// tests/terse.test.mjs
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const terse = readFileSync('skills/terse/SKILL.md', 'utf8')
+
+test('states every shaping rule', () => {
+  for (const phrase of [
+    'Lead with the action',
+    'Restate position',
+    'One concrete next action',
+    'Cap narration lists',
+    'Pre-send deletion pass',
+  ]) {
+    assert.match(terse, new RegExp(phrase, 'i'), `${phrase} missing`)
+  }
+})
+
+// Without the exemption the cap becomes a licence to drop the sixth blocker.
+test('subordinates the cap and the deletion pass to the never-compress list', () => {
+  const section = terse.slice(terse.search(/##\s+Shaping/i))
+  assert.match(section, /never[- ]compress/i, 'the exemption must name the never-compress list')
+  assert.match(section, /narration/i, 'the exemption must scope the rules to narration')
+})
+
+// The tells measured 0.00 against a 0.00 baseline at n=10, in two positions,
+// on 2026-08-11. This test is what stops them returning unnoticed.
+test('omits the tells that measured inert', () => {
+  assert.doesNotMatch(terse, /No em dash/i)
+})
+
+// description and trigger are what the runtime shows the model before it decides
+// to invoke a skill, and trigger feeds three generated tables. Changing either
+// changes firing, which five scenarios measure. Pinned by value rather than by
+// diff against HEAD: a diff against HEAD passes trivially once committed.
+test('pins the frontmatter that drives firing', () => {
+  assert.match(terse, /^trigger: First response of the session — invoke once, then it stays on$/m)
+  assert.match(terse, /^gate: none$/m)
+  assert.match(terse, /^description: Use at the start of every session — compress narration, never artifacts\./m)
+})


### PR DESCRIPTION
**Spec:** `docs/specs/2026-08-12-terse-shaping-rules-design.md`
**Plan:** `docs/plans/2026-08-12-terse-shaping-rules.md`

`terse` says what to cut and nothing about the order what survives arrives in. This adds five shaping rules and the exemption that keeps them safe:

1. Lead with the action
2. Restate position every turn
3. One concrete next action
4. Cap narration lists at five
5. Pre-send deletion pass

The rule that motivated it: an eight-task `exec` run reported every task's outcome without once saying which task of eight had finished. The reader had to count, and `terse` forbade none of it, because every rule it carried was about deletion.

### Why this is not a third attempt at a failed thing

Two runs on 2026-08-11 put a section carrying *both* shaping rules and stop-slop-style tells into `terse`, measured 0.00 against a 0.00 baseline at n=10, and reverted it. Then moved it to the top of the file, measured 0.00 again, reverted again.

The scenario behind both numbers is `terse-omits-em-dash`. **It tests one tell. It never tested a single shaping rule** — the round 1 spec said so in advance, since restating position needs a multi-turn fixture, leading with the action has no assertion that survives legitimate variation, and the deletion pass leaves no trace. Both reverts discarded an untested component because a tested component beside it failed.

So this ships the untested half and leaves the measured-dead half out. `tests/terse.test.mjs` has a test asserting `No em dash` does **not** appear, so the tells cannot return unnoticed.

The text is recovered from commit `603b487` rather than rewritten, minus the `### Tells` subsection. It is the wording drafted, reviewed and approved yesterday.

### The exemption

The cap and the deletion pass govern narration only. Neither touches the never-compress list: a findings list, a blocker enumeration, a goals walk, a question to the user, quoted evidence, a destructive-operation warning. A cap that can truncate findings is a licence to drop the sixth blocker, so the exemption carries its own test.

### Firing cannot move

Frontmatter is byte-identical. `description` and `trigger` are what the runtime shows the model before it decides to invoke a skill, and `lib/model.mjs` feeds `trigger` into three generated trigger tables. `git diff` on the skill contains no frontmatter line, and a test pins the trigger, gate and description by value rather than by diffing against `HEAD`, which would pass trivially once committed.

### Checks at `d14ba7b`

- `npm test` — exit 0, 197 tests, 197 pass, 0 fail (193 before)
- `npm run check` — exit 0
- `grep -c Tells skills/terse/SKILL.md` — 0
- tree clean; `skills/terse/SKILL.md` is the only path under `skills/` in the diff

Two of the four new tests were observed failing before the change and passing after. The other two pinned values that already held, and the implementer reported them as such rather than counting them as evidence.

### Shipping on judgment, said plainly

**No paid run, and no rate is claimed.** Three of the five rules cannot be measured by this harness. The spec says so rather than inventing a scenario that passes vacuously. The argument for shipping is that these rules are structural rather than stylistic, and structural instruction is what every working skill in this repo is made of. The contrary view is in the spec's Open questions: two nulls in one day argue for spending nothing further on output shaping.

`terse` is now 110 lines and always active, so every session pays for it in input tokens. Nothing has measured whether that is worth rules whose effect is unknown.