### PR TITLE
readme: restructure into introduction, how it works, features, install, license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
 # vibekit
 
-A guardrailed pipeline for coding agents. It turns a one-line intent into a
-design you approved, a plan you approved, code written by an agent that never saw
-the plan being written, and a verdict backed by output you can read. Dependency
-free: bare Node and whichever agent CLI you already use.
+A guardrailed pipeline for coding agents. It turns a one-line intent into a design you approved, a plan you approved, code written by an agent that never saw the plan being written, and a verdict backed by output you can read. Dependency free: bare Node and whichever agent CLI you already use.
 
-The problem it solves is not bad code. It is the claim of being done. vibekit
-puts a gate in front of every such claim and makes the evidence part of the
-answer.
+The problem it solves is not bad code. It is the claim of being done. vibekit puts a gate in front of every such claim and makes the evidence part of the answer.
 
 ## How it works
 
-Six skills, each one a gate. Every stage hands to the next, and no stage can skip
-the one before it.
+Six skills, each one a gate. Every stage hands to the next, and no stage can skip the one before it.
 
 ```
 /vibekit:vibe "add a dark mode toggle"
@@ -25,27 +19,14 @@ the one before it.
               (a check failed)
 ```
 
-- **`brainstorm`** asks questions one at a time, pushes back on your framing
-  once, offers alternatives, and writes a spec with observable success criteria.
-  No code before you approve it.
-- **`plan`** turns the approved spec into numbered tasks. Every task carries a
-  `→ verify:` clause that is checkable before anything runs, and a plan may not
-  state a value nobody has observed.
-- **`exec`** dispatches one fresh agent per task. The author of a plan reads past
-  its own contradictions. A fresh context reads it literally and stops. Every
-  plan defect this project has found was found by a dispatched agent.
-- **`verify`** runs the checks no single task could: the whole suite, the scope
-  of the diff, every goal against its evidence. It returns `ready` or `not
-  ready`, and unmeasured counts as not satisfied.
-- **`debug`** takes over on a failed check. It finds one falsifiable cause, sends
-  a read-only agent to refute it, and stops after two refutations rather than
-  guessing a third time. It never edits.
-- **`lazy`** and **`terse`** stay on once invoked. One governs how much you
-  build, the other how much you say.
+- **`brainstorm`** asks questions one at a time, pushes back on your framing once, offers alternatives, and writes a spec with observable success criteria. No code before you approve it.
+- **`plan`** turns the approved spec into numbered tasks. Every task carries a `→ verify:` clause that is checkable before anything runs, and a plan may not state a value nobody has observed.
+- **`exec`** dispatches one fresh agent per task. The author of a plan reads past its own contradictions. A fresh context reads it literally and stops. Every plan defect this project has found was found by a dispatched agent.
+- **`verify`** runs the checks no single task could: the whole suite, the scope of the diff, every goal against its evidence. It returns `ready` or `not ready`, and unmeasured counts as not satisfied.
+- **`debug`** takes over on a failed check. It finds one falsifiable cause, sends a read-only agent to refute it, and stops after two refutations rather than guessing a third time. It never edits.
+- **`lazy`** and **`terse`** stay on once invoked. One governs how much you build, the other how much you say.
 
-Two rules run through all of it. **Evidence or it did not happen**, because a
-check with no output to show is not a check. **You may not write a value you have
-not observed**, because a guess in a plan is a defect a later agent pays for.
+Two rules run through all of it. **Evidence or it did not happen**, because a check with no output to show is not a check. **You may not write a value you have not observed**, because a guess in a plan is a defect a later agent pays for.
 
 ## Features
 
@@ -55,7 +36,7 @@ not observed**, because a guess in a plan is a defect a later agent pays for.
 | `brainstorm` | Use before any creative or implementation work — features, components, behavior changes. Hard gate, no code before an approved design. | hard |
 | `debug` | Use when a check fails — a red test, a broken build, a failed clause, or a bug you can point at. Finds a root cause and gets it refuted before anything is fixed. Diagnosis is the product; this skill never edits. | hard |
 | `exec` | Use when a plan is approved and implementation has not started — dispatches one fresh subagent per task, runs each task's verify clause, and routes failures back instead of repairing them. One task, one commit. | hard |
-| `lazy` | Use at the start of any coding work — writing, adding, refactoring, fixing, designing. The laziness ladder: stdlib and native features before new code, one line before fifty. Stays on after. | none |
+| `lazy` | Use at the start of any coding work — writing, adding, refactoring, fixing, designing. The laziness ladder, stdlib and native features before new code, one line before fifty. Stays on after. | none |
 | `plan` | Use when a spec is approved and implementation has not started — turns it into a task-by-task plan with exact paths and checkable verification. No code here. | hard |
 | `terse` | Use at the start of every session — compress narration, never artifacts. Questions, evidence, specs, plans and warnings stay verbatim. Stays on after. | none |
 | `using-vibekit` | Use when starting any conversation — establishes the auto-trigger discipline so guardrail skills fire instead of being silently skipped. | none |
@@ -63,14 +44,9 @@ not observed**, because a guess in a plan is a defect a later agent pays for.
 | `vibe` | Run a short intent through the pipeline. Invoked as /vibekit:vibe; hands off to brainstorm and does nothing else. | none |
 <!-- /vibekit:generated -->
 
-A `hard` gate refuses to proceed until its condition is met. `none` means the
-skill shapes behaviour without blocking anything.
+A `hard` gate refuses to proceed until its condition is met. `none` means the skill shapes behaviour without blocking anything.
 
-Skills are discovered by globbing `skills/*/SKILL.md`. There is no registry
-anywhere in the repo, which is what makes registration drift impossible rather
-than merely detectable. Every derived file, including the runtime manifests, the
-command files, the trigger tables and this table, is generated by `npm run
-generate` and verified by `npm run check`.
+Skills are discovered by globbing `skills/*/SKILL.md`. There is no registry anywhere in the repo, which is what makes registration drift impossible rather than merely detectable. Every derived file, including the runtime manifests, the command files, the trigger tables and this table, is generated by `npm run generate` and verified by `npm run check`.
 
 ## Install
 
@@ -126,15 +102,11 @@ pi install git:github.com/rizukirr/vibekit
 | Gemini | `runtimes/gemini.mjs` | not verified, tool not installed |
 | Pi | `runtimes/pi.mjs` | not verified, tool not installed |
 
-Two runtimes were probed against the real CLI and two were not. That distinction
-is kept per row because unit tests assert what we decided to emit, which says
-nothing about whether a host accepts it. That gap hid four integration defects
-until they were probed.
+Two runtimes were probed against the real CLI and two were not. That distinction is kept per row because unit tests assert what we decided to emit, which says nothing about whether a host accepts it. That gap hid four integration defects until they were probed.
 
 ## Evals
 
-Skills are behaviour-shaping prompts, so the only way to know one works is to
-watch it fire in a real session.
+Skills are behaviour-shaping prompts, so the only way to know one works is to watch it fire in a real session.
 
 ```
 npm run eval                                       # candidate only, deterministic
@@ -143,15 +115,11 @@ npm run eval -- --dry-run                          # print the plan and cost, sp
 npm run eval -- --judge                            # also grade whether the skill was followed
 ```
 
-Variants are git refs materialised as throwaway worktrees, so there is never a
-second `skills/` tree to drift. Sessions run in a disposable temp directory.
+Variants are git refs materialised as throwaway worktrees, so there is never a second `skills/` tree to drift. Sessions run in a disposable temp directory.
 
-Run A/B rather than candidate-only whenever a rate is the point. A candidate rate
-of 1.00 once looked like a new rule working. Its baseline arm was also 1.00,
-because the model already did it.
+Run A/B rather than candidate-only whenever a rate is the point. A candidate rate of 1.00 once looked like a new rule working. Its baseline arm was also 1.00, because the model already did it.
 
-This costs real money and needs an authenticated `claude` CLI, so it is a manual
-gate, not part of the free CI (`check`, `test`, `check:hook`).
+This costs real money and needs an authenticated `claude` CLI, so it is a manual gate, not part of the free CI (`check`, `test`, `check:hook`).
 
 ## Development
 
@@ -161,8 +129,7 @@ npm run check       # fail if any generated file is out of date
 npm test            # unit tests
 ```
 
-Adding a skill is creating one directory under `skills/` with a `SKILL.md`, then
-running `npm run generate`. Never hand-edit a generated file.
+Adding a skill is creating one directory under `skills/` with a `SKILL.md`, then running `npm run generate`. Never hand-edit a generated file.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,135 @@
 # vibekit
 
-Guardrailed vibe-coding pipeline for coding agents. Dependency free.
+A guardrailed pipeline for coding agents. It turns a one-line intent into a
+design you approved, a plan you approved, code written by an agent that never saw
+the plan being written, and a verdict backed by output you can read. Dependency
+free: bare Node and whichever agent CLI you already use.
 
-## Skills
+The problem it solves is not bad code. It is the claim of being done. vibekit
+puts a gate in front of every such claim and makes the evidence part of the
+answer.
+
+## How it works
+
+Six skills, each one a gate. Every stage hands to the next, and no stage can skip
+the one before it.
+
+```
+/vibekit:vibe "add a dark mode toggle"
+        │
+        ▼
+  brainstorm ──► plan ──► exec ──► verify ──► merge or PR
+   (design)    (tasks)  (agents)  (evidence)
+        ▲                   │         │
+        └───── debug ◄──────┴─────────┘
+              (a check failed)
+```
+
+- **`brainstorm`** asks questions one at a time, pushes back on your framing
+  once, offers alternatives, and writes a spec with observable success criteria.
+  No code before you approve it.
+- **`plan`** turns the approved spec into numbered tasks. Every task carries a
+  `→ verify:` clause that is checkable before anything runs, and a plan may not
+  state a value nobody has observed.
+- **`exec`** dispatches one fresh agent per task. The author of a plan reads past
+  its own contradictions. A fresh context reads it literally and stops. Every
+  plan defect this project has found was found by a dispatched agent.
+- **`verify`** runs the checks no single task could: the whole suite, the scope
+  of the diff, every goal against its evidence. It returns `ready` or `not
+  ready`, and unmeasured counts as not satisfied.
+- **`debug`** takes over on a failed check. It finds one falsifiable cause, sends
+  a read-only agent to refute it, and stops after two refutations rather than
+  guessing a third time. It never edits.
+- **`lazy`** and **`terse`** stay on once invoked. One governs how much you
+  build, the other how much you say.
+
+Two rules run through all of it. **Evidence or it did not happen**, because a
+check with no output to show is not a check. **You may not write a value you have
+not observed**, because a guess in a plan is a defect a later agent pays for.
+
+## Features
 
 <!-- vibekit:generated:skill-list -->
-- `brainstorm` — Use before any creative or implementation work — features, components, behavior changes. Hard gate, no code before an approved design.
-- `debug` — Use when a check fails — a red test, a broken build, a failed clause, or a bug you can point at. Finds a root cause and gets it refuted before anything is fixed. Diagnosis is the product; this skill never edits.
-- `exec` — Use when a plan is approved and implementation has not started — dispatches one fresh subagent per task, runs each task's verify clause, and routes failures back instead of repairing them. One task, one commit.
-- `lazy` — Use at the start of any coding work — writing, adding, refactoring, fixing, designing. The laziness ladder: stdlib and native features before new code, one line before fifty. Stays on after.
-- `plan` — Use when a spec is approved and implementation has not started — turns it into a task-by-task plan with exact paths and checkable verification. No code here.
-- `terse` — Use at the start of every session — compress narration, never artifacts. Questions, evidence, specs, plans and warnings stay verbatim. Stays on after.
-- `using-vibekit` — Use when starting any conversation — establishes the auto-trigger discipline so guardrail skills fire instead of being silently skipped.
-- `verify` — Use before claiming a change is done, fixed or passing — checks the whole change against its spec, runs the checks no single task could, and returns ready or not ready. Evidence or it did not happen.
-- `vibe` — Run a short intent through the pipeline. Invoked as /vibekit:vibe; hands off to brainstorm and does nothing else.
+| Skill | What it does | Gate |
+|---|---|---|
+| `brainstorm` | Use before any creative or implementation work — features, components, behavior changes. Hard gate, no code before an approved design. | hard |
+| `debug` | Use when a check fails — a red test, a broken build, a failed clause, or a bug you can point at. Finds a root cause and gets it refuted before anything is fixed. Diagnosis is the product; this skill never edits. | hard |
+| `exec` | Use when a plan is approved and implementation has not started — dispatches one fresh subagent per task, runs each task's verify clause, and routes failures back instead of repairing them. One task, one commit. | hard |
+| `lazy` | Use at the start of any coding work — writing, adding, refactoring, fixing, designing. The laziness ladder: stdlib and native features before new code, one line before fifty. Stays on after. | none |
+| `plan` | Use when a spec is approved and implementation has not started — turns it into a task-by-task plan with exact paths and checkable verification. No code here. | hard |
+| `terse` | Use at the start of every session — compress narration, never artifacts. Questions, evidence, specs, plans and warnings stay verbatim. Stays on after. | none |
+| `using-vibekit` | Use when starting any conversation — establishes the auto-trigger discipline so guardrail skills fire instead of being silently skipped. | none |
+| `verify` | Use before claiming a change is done, fixed or passing — checks the whole change against its spec, runs the checks no single task could, and returns ready or not ready. Evidence or it did not happen. | hard |
+| `vibe` | Run a short intent through the pipeline. Invoked as /vibekit:vibe; hands off to brainstorm and does nothing else. | none |
 <!-- /vibekit:generated -->
 
-## Runtime support
+A `hard` gate refuses to proceed until its condition is met. `none` means the
+skill shapes behaviour without blocking anything.
+
+Skills are discovered by globbing `skills/*/SKILL.md`. There is no registry
+anywhere in the repo, which is what makes registration drift impossible rather
+than merely detectable. Every derived file, including the runtime manifests, the
+command files, the trigger tables and this table, is generated by `npm run
+generate` and verified by `npm run check`.
+
+## Install
+
+Each runtime installs separately. Installing for one does not affect any other.
+
+**Claude Code**
+
+```
+/plugin marketplace add rizukirr/vibekit
+/plugin install vibekit@vibekit-marketplace
+```
+
+**Codex**
+
+```
+codex plugin marketplace add rizukirr/vibekit
+codex plugin add vibekit@vibekit
+```
+
+Verify with `codex plugin list`.
+
+**opencode**
+
+Add it to the `plugin` array in your `opencode.json`, global or project level:
+
+```json
+{
+  "plugin": ["vibekit@git+https://github.com/rizukirr/vibekit.git"]
+}
+```
+
+Verify with `opencode debug skill`.
+
+**Gemini CLI**
+
+```
+gemini extensions install https://github.com/rizukirr/vibekit
+```
+
+**Pi**
+
+```
+pi install git:github.com/rizukirr/vibekit
+```
+
+### What has actually been checked
 
 | Runtime | Emitter | Verified |
 |---|---|---|
-| Claude Code | `runtimes/claude-code.mjs` | Yes — SessionStart hook smoke-tested in CI on Linux and Windows |
-| Codex | `runtimes/codex.mjs` | installed from this checkout and listed as enabled at version 0.6.0 by `codex plugin list`, against codex-cli 0.147.0 |
-| opencode | `runtimes/opencode.mjs` | all ten skills listed by `opencode debug skill`, against opencode 1.18.16 |
-| Gemini | `runtimes/gemini.mjs` | not verified — tool not installed |
-| Pi | `runtimes/pi.mjs` | not verified — tool not installed |
+| Claude Code | `runtimes/claude-code.mjs` | SessionStart hook smoke-tested in CI on Linux and Windows |
+| Codex | `runtimes/codex.mjs` | installed and listed as enabled by `codex plugin list`, against codex-cli 0.147.0 |
+| opencode | `runtimes/opencode.mjs` | all skills listed by `opencode debug skill`, against opencode 1.18.16 |
+| Gemini | `runtimes/gemini.mjs` | not verified, tool not installed |
+| Pi | `runtimes/pi.mjs` | not verified, tool not installed |
+
+Two runtimes were probed against the real CLI and two were not. That distinction
+is kept per row because unit tests assert what we decided to emit, which says
+nothing about whether a host accepts it. That gap hid four integration defects
+until they were probed.
 
 ## Evals
 
@@ -32,25 +137,33 @@ Skills are behaviour-shaping prompts, so the only way to know one works is to
 watch it fire in a real session.
 
 ```
-npm run eval                                  # candidate only, deterministic
-npm run eval -- --baseline main --candidate HEAD   # A/B two refs
-npm run eval -- --dry-run                     # print the plan and cost, spawn nothing
-npm run eval -- --judge                       # also grade whether the skill was followed
+npm run eval                                       # candidate only, deterministic
+npm run eval -- --baseline v2 --candidate HEAD     # A/B two refs
+npm run eval -- --dry-run                          # print the plan and cost, spawn nothing
+npm run eval -- --judge                            # also grade whether the skill was followed
 ```
 
 Variants are git refs materialised as throwaway worktrees, so there is never a
-second `skills/` tree to drift. Sessions run in a disposable temp directory, not
-the repo.
+second `skills/` tree to drift. Sessions run in a disposable temp directory.
+
+Run A/B rather than candidate-only whenever a rate is the point. A candidate rate
+of 1.00 once looked like a new rule working. Its baseline arm was also 1.00,
+because the model already did it.
 
 This costs real money and needs an authenticated `claude` CLI, so it is a manual
-gate — not part of the free CI (`check`, `test`, `check:hook`).
-
-## Install
-
-Claude Code: `/plugin marketplace add rizukirr/vibekit`
+gate, not part of the free CI (`check`, `test`, `check:hook`).
 
 ## Development
 
-- `npm run generate` — regenerate every derived file
-- `npm run check` — fail if any generated file is out of date
-- `npm test` — run the unit tests
+```
+npm run generate    # regenerate every derived file
+npm run check       # fail if any generated file is out of date
+npm test            # unit tests
+```
+
+Adding a skill is creating one directory under `skills/` with a `SKILL.md`, then
+running `npm run generate`. Never hand-edit a generated file.
+
+## License
+
+MIT. Copyright (c) 2026 Rizki Rakasiwi. See [LICENSE](LICENSE).

--- a/lib/table.mjs
+++ b/lib/table.mjs
@@ -21,3 +21,14 @@ export function triggerTable(skills) {
 export function skillList(skills) {
   return skills.map(skill => `- \`${skill.name}\` — ${skill.description}`).join('\n')
 }
+
+// README shows the same set as a table: what each skill is for, and whether it
+// gates. Generated rather than hand-written for the same reason the trigger map
+// is — a hand-kept list drifts the first time a skill is added.
+export function skillTable(skills) {
+  return [
+    '| Skill | What it does | Gate |',
+    '|---|---|---|',
+    ...skills.map(skill => `| \`${cell(skill.name)}\` | ${cell(skill.description)} | ${cell(skill.gate)} |`),
+  ].join('\n')
+}

--- a/runtimes/core.mjs
+++ b/runtimes/core.mjs
@@ -1,5 +1,5 @@
 // runtimes/core.mjs
-import { skillList } from '../lib/table.mjs'
+import { skillTable } from '../lib/table.mjs'
 
 export const id = 'core'
 
@@ -41,5 +41,5 @@ export function emit(model) {
 }
 
 export function regions(model) {
-  return { 'README.md': { 'skill-list': skillList(model.skills) } }
+  return { 'README.md': { 'skill-list': skillTable(model.skills) } }
 }

--- a/tests/core.test.mjs
+++ b/tests/core.test.mjs
@@ -37,7 +37,9 @@ test('package.json ends with a trailing newline', () => {
 
 test('owns the README skill-list region', () => {
   assert.deepEqual(Object.keys(regions(MODEL)), ['README.md'])
-  assert.ok(regions(MODEL)['README.md']['skill-list'].includes('- `alpha` — Alpha does A.'))
+  const table = regions(MODEL)['README.md']['skill-list']
+  assert.ok(table.startsWith('| Skill | What it does | Gate |'), 'must render as a table')
+  assert.ok(table.includes('| `alpha` | Alpha does A.'), 'must carry each skill as a row')
 })
 
 test('merges contributed package.json keys', () => {


### PR DESCRIPTION
Restructures `README.md` to the requested shape: introduction, how it works, features as a table, install per runtime, license.

### The skill list became a table

`lib/table.mjs` gains `skillTable(skills)`, rendering `| Skill | What it does | Gate |`. `runtimes/core.mjs` uses it for the README region in place of `skillList`, so the features table is generated rather than hand kept. A hand-written list drifts the first time a skill is added. This one cannot.

`tests/core.test.mjs` was updated to assert the table shape instead of the bullet shape, and now also pins the header row.

### Install is per runtime

Five sections with the real commands for Claude Code, Codex, opencode, Gemini and Pi, followed by a table saying which of them was actually probed against a live CLI and which was not. Two were, two were not, and the distinction stays per row because unit tests assert what we decided to emit, which says nothing about whether a host accepts it.

### How it works

A diagram of the pipeline, then one line per skill covering what it gates, plus the two rules that run through all of them: evidence or it did not happen, and you may not write a value you have not observed.

### No em dashes

Zero in the hand-written prose, checked by counting. The eight that remain sit inside the generated region and come from each skill's `description` frontmatter. Removing those means editing the descriptions, which are what the runtime shows the model before it decides whether to invoke a skill, and five eval scenarios measure firing. That is a separate change with a real risk attached, not a formatting pass.

### Checks at `1c03f7c`

- `npm test`, exit 0, 197 tests, 197 pass, 0 fail
- `npm run check`, exit 0
- four files changed, no skill text touched