### PR TITLE
quick skill

### DIFF
--- a/.vibekit-manifest
+++ b/.vibekit-manifest
@@ -9,6 +9,8 @@ AGENTS.md
 CLAUDE.md
 GEMINI.md
 README.md
+commands/quick.md
+commands/quick.toml
 commands/vibe.md
 commands/vibe.toml
 gemini-extension.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ invoked by following the named workflow.
 | Plan approved, implementation not yet started | `exec` | hard |
 | First moment of any coding work — invoke once, then it stays on | `lazy` | none |
 | Spec approved, implementation not yet started | `plan` | hard |
+| Invoked explicitly as a slash command — never fires on its own | `quick` | none |
 | First response of the session — invoke once, then it stays on | `terse` | none |
 | Session start | `using-vibekit` | none |
 | Implementation complete, before any claim that work is done | `verify` | hard |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Guardrailed vibe-coding pipeline. Skills auto-trigger at their trigger points.
 | Plan approved, implementation not yet started | `exec` | hard |
 | First moment of any coding work — invoke once, then it stays on | `lazy` | none |
 | Spec approved, implementation not yet started | `plan` | hard |
+| Invoked explicitly as a slash command — never fires on its own | `quick` | none |
 | First response of the session — invoke once, then it stays on | `terse` | none |
 | Session start | `using-vibekit` | none |
 | Implementation complete, before any claim that work is done | `verify` | hard |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,6 +13,7 @@ invoked by following the named workflow.
 | Plan approved, implementation not yet started | `exec` | hard |
 | First moment of any coding work — invoke once, then it stays on | `lazy` | none |
 | Spec approved, implementation not yet started | `plan` | hard |
+| Invoked explicitly as a slash command — never fires on its own | `quick` | none |
 | First response of the session — invoke once, then it stays on | `terse` | none |
 | Session start | `using-vibekit` | none |
 | Implementation complete, before any claim that work is done | `verify` | hard |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Two rules run through all of it. **Evidence or it did not happen**, because a ch
 | `exec` | Use when a plan is approved and implementation has not started — dispatches one fresh subagent per task, runs each task's verify clause, and routes failures back instead of repairing them. One task, one commit. | hard |
 | `lazy` | Use at the start of any coding work — writing, adding, refactoring, fixing, designing. The laziness ladder, stdlib and native features before new code, one line before fifty. Stays on after. | none |
 | `plan` | Use when a spec is approved and implementation has not started — turns it into a task-by-task plan with exact paths and checkable verification. No code here. | hard |
+| `quick` | Use when the user types /vibekit:quick — writes the change immediately under lazy's ladder, no spec, no plan, no subagents. Reports what it skipped. | none |
 | `terse` | Use at the start of every session — compress narration, never artifacts. Questions, evidence, specs, plans and warnings stay verbatim. Stays on after. | none |
 | `using-vibekit` | Use when starting any conversation — establishes the auto-trigger discipline so guardrail skills fire instead of being silently skipped. | none |
 | `verify` | Use before claiming a change is done, fixed or passing — checks the whole change against its spec, runs the checks no single task could, and returns ready or not ready. Evidence or it did not happen. | hard |

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -1,0 +1,8 @@
+---
+description: Use when the user types /vibekit:quick — writes the change immediately under lazy's ladder, no spec, no plan, no subagents. Reports what it skipped.
+argument-hint: <intent>
+---
+
+Invoke the `quick` skill and follow it exactly.
+
+**User intent:** $ARGUMENTS

--- a/commands/quick.toml
+++ b/commands/quick.toml
@@ -1,0 +1,7 @@
+description = "Use when the user types /vibekit:quick — writes the change immediately under lazy's ladder, no spec, no plan, no subagents. Reports what it skipped."
+
+prompt = """
+Invoke the `quick` skill and follow it exactly.
+
+User intent: {{args}}
+"""

--- a/skills/quick/SKILL.md
+++ b/skills/quick/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: quick
+description: Use when the user types /vibekit:quick — writes the change immediately under lazy's ladder, no spec, no plan, no subagents. Reports what it skipped.
+trigger: Invoked explicitly as a slash command — never fires on its own
+gate: none
+command: true
+---
+
+# quick
+
+The fast path. One intent in, the change written now.
+
+## The waiver
+
+`brainstorm`, `plan`, `exec` and `verify` do not apply here. No spec doc, no plan
+doc, no subagent dispatch, no verification report. That is the whole point of
+typing this instead of `/vibekit:vibe`.
+
+Invoke `lazy` and write under its ladder. Do not restate its rungs — one copy of
+the ladder exists, and it lives in `lazy`.
+
+## Bail out first
+
+Check before writing. Each of these is a fact about the change, not a judgement
+about its size:
+
+- It needs a dependency that is not already installed.
+- It touches a schema, a migration, or the shape of stored data.
+- It touches auth, payments, permissions, or any other trust boundary.
+- It spans more files than you can hold in one reading.
+- The intent reads two ways.
+
+Any one of them: stop, name the criterion that tripped, and say the request wants
+`brainstorm`. Do not start a spec yourself, and do not negotiate — the user asked
+for speed, and the honest answer is that this is not the path for it.
+
+None of them: write the change now.
+
+## The floor still holds
+
+Nothing runs behind you, so `lazy`'s never-simplify-away list is not optional
+here: validation at trust boundaries, error handling that prevents data loss,
+security, accessibility, and anything the user explicitly asked for.
+
+Non-trivial logic leaves one runnable check, and **you run it**. `verify` is not
+coming. A change you did not execute is a change you are guessing about, and
+"evidence or it did not happen" is not waived by speed.
+
+## debug is not waived
+
+A failed check routes to `debug` exactly as it always does. `quick` skips the
+gates before implementation. It does not skip the one after a failure.
+
+## Say what you skipped
+
+Close with one line naming the skipped stages and the check you ran, so a fast
+path never reads like a verified one:
+
+> Skipped: brainstorm, plan, exec, verify. Ran: <the check, and its result>.


### PR DESCRIPTION
## Summary

Adds `quick`, a command skill that waives the pre-implementation gates and writes the change immediately under `lazy`'s ladder.

`/vibekit:vibe` is currently the only door, and it hands to `brainstorm`, a hard gate that applies "regardless of perceived simplicity". A typo costs a spec doc, a plan doc, a subagent dispatch and a verification report.

The escape hatch nominally exists — `using-vibekit` ranks explicit user instructions above every skill — but two measurements on this repo say prose permission is not permission: a stated rule measured 0.00 against 0.00, and a modifier's description line measured 0/5 firing until invoked explicitly. `lazy` does not close the gap either: it governs how short the code is once writing is permitted, grants no permission to write, and is not a generated command in any runtime.

Both are local-only — `/docs` is gitignored on this repo, so neither file appears in this diff.

## Changes

New file `skills/quick/SKILL.md`, with `command: true` and `gate: none`. Everything else in the diff is generator output from `npm run generate`.

- **Waiver** — names `brainstorm`, `plan`, `exec` and `verify` as not applying, and invokes `lazy` rather than restating its rungs, so one copy of the ladder exists.
- **Bail-out** — five checkable facts about the change: uninstalled dependency, schema or migration, trust boundary, more files than one reading holds, ambiguous intent. Any one of them: stop and name the criterion that tripped, do not start a spec.
- **Floor** — `lazy`'s never-simplify-away list still holds, and the one runnable check is executed here, since no `verify` follows.
- **`debug` is not waived** — `quick` skips the gates before implementation, never the one after a failure.
- **Disclosure** — closes by naming the skipped stages and the check that ran, so a fast path never reads like a verified one.

It never auto-fires. Its trigger copies `vibe`'s wording, so it is reachable only by an explicit keystroke.

Generated alongside it: `commands/quick.md`, `commands/quick.toml`, trigger-table rows in `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`, the `README.md` skill list, and `.vibekit-manifest`. No emitter, test or manifest source was edited.

## Result

Sweep against `59a57b6`:

- `npm test` — exit 0, `fail 0`
- `npm run check` — exit 0
- `git status --porcelain` — empty
- Every file in the diff is claimed by the plan's `Files` block

All eight spec goals `satisfied`, each with observed evidence. No non-goal built.

**Open:**

- `warn` — `skills/quick/SKILL.md:41-43` restates `lazy`'s never-simplify-away list rather than referencing it (rung 2). Left inline deliberately: a referenced rule reaches an implementer weaker than an inlined one.

**Not observed:**

- Whether the skill behaves as written. Nothing executes it, and this change is entirely prose. An eval is the next cycle.
- Whether `/quick` appears in opencode, pi or gemini. Only claude-code and codex emit command files; the rest was read from emitters, not run.