### PR TITLE
parse fired not attempted

### DIFF
--- a/evals/fixtures/skill-unavailable.jsonl
+++ b/evals/fixtures/skill-unavailable.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","model":"claude-haiku-4-5-20251001","tools":["Bash","Read","Skill"],"skills":["vibekit:example-command","vibekit:using-vibekit"],"slash_commands":["vibekit:example-command"]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"vibekit:example-plain"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","is_error":true,"content":"<tool_use_error>Unknown skill: vibekit:example-plain</tool_use_error>"}]}}
+{"type":"result","subtype":"success","is_error":false,"num_turns":2,"total_cost_usd":0.0239948,"usage":{"input_tokens":2,"cache_creation_input_tokens":12892,"cache_read_input_tokens":23686,"output_tokens":283}}

--- a/evals/fixtures/skill-unavailable.jsonl
+++ b/evals/fixtures/skill-unavailable.jsonl
@@ -1,4 +1,3 @@
 {"type":"system","subtype":"init","model":"claude-haiku-4-5-20251001","tools":["Bash","Read","Skill"],"skills":["vibekit:example-command","vibekit:using-vibekit"],"slash_commands":["vibekit:example-command"]}
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"vibekit:example-plain"}}]}}
-{"type":"user","message":{"role":"user","content":[{"type":"tool_result","is_error":true,"content":"<tool_use_error>Unknown skill: vibekit:example-plain</tool_use_error>"}]}}
 {"type":"result","subtype":"success","is_error":false,"num_turns":2,"total_cost_usd":0.0239948,"usage":{"input_tokens":2,"cache_creation_input_tokens":12892,"cache_read_input_tokens":23686,"output_tokens":283}}

--- a/evals/parse.mjs
+++ b/evals/parse.mjs
@@ -64,17 +64,30 @@ export function parseTranscript(text) {
     }
   }
 
+  // A Skill block records an attempt, not a load. The runtime can only load a
+  // skill it offered, so an attempt naming something outside initSkills came
+  // back as "Unknown skill" and the body was never read. Counting those as
+  // fired let sessions report a skill as fired in a worktree lacking it.
+  //
+  // Filtered here rather than at each expectation so one definition of "fired"
+  // serves all three consumers in score.mjs: skill, after and skillAbsent.
+  //
+  // tools and dispatches are deliberately NOT filtered. They record a decision
+  // the model made, and an errored Write still means the session chose to write
+  // before designing, which is what the `before` expectation catches.
+  const fired = skills.filter(s => initSkills.includes(s.name))
+
   // A session that produced no result event did not complete. Treating that as
   // "the skill did not fire" would let an API failure masquerade as a
   // behavioural regression, so it is an error instead.
   if (subtype === null) {
-    return { ok: false, error: 'no result event', skills, tools, dispatches, usage, cost, subtype, initSkills, finalText }
+    return { ok: false, error: 'no result event', skills: fired, tools, dispatches, usage, cost, subtype, initSkills, finalText }
   }
 
   return {
     ok: subtype === 'success' && isError !== true,
     error: null,
-    skills,
+    skills: fired,
     tools,
     dispatches,
     usage,

--- a/evals/score.mjs
+++ b/evals/score.mjs
@@ -96,7 +96,15 @@ function unsatisfiedReason(scenario, run) {
   }
   if (expect.skill !== undefined) {
     const hit = run.skills.find(s => s.name === expect.skill)
-    if (!hit) return `skill ${expect.skill} never fired`
+    if (!hit) {
+      // Only claim unavailability when the transcript says what was offered. A
+      // run object carrying no initSkills says nothing either way, so it keeps
+      // the original wording rather than asserting something unobserved.
+      const offered = run.initSkills ?? []
+      return offered.length && !offered.includes(expect.skill)
+        ? `skill ${expect.skill} was not available to the session`
+        : `skill ${expect.skill} never fired`
+    }
     for (const forbidden of expect.before ?? []) {
       const earlier = run.tools.find(t => t.name === forbidden && t.index < hit.index)
       if (earlier) return `${forbidden} used before ${expect.skill}`

--- a/tests/eval-parse.test.mjs
+++ b/tests/eval-parse.test.mjs
@@ -98,3 +98,18 @@ test('caps a stored prompt and records the original length', () => {
   assert.equal(d.prompt.length, 4000)
   assert.equal(d.promptLength, 5000)
 })
+
+test('a skill the session was never offered is not reported as fired', () => {
+  const t = parseTranscript(fixture('skill-unavailable'))
+  assert.equal(t.ok, true)
+  assert.deepEqual(t.skills, [])
+})
+
+// The attempt stays in `tools` on purpose. `before` reads run.tools to enforce
+// the brainstorm gate, and a session that tried to act still made the decision
+// the gate exists to catch. Without this test, filtering `tools` to match
+// `skills` looks like a tidy-up rather than a weakening of that gate.
+test('an attempted skill is still recorded in tools', () => {
+  const t = parseTranscript(fixture('skill-unavailable'))
+  assert.ok(t.tools.some(u => u.name === 'Skill'), 'tools must record the attempt')
+})

--- a/tests/eval-score.test.mjs
+++ b/tests/eval-score.test.mjs
@@ -477,3 +477,15 @@ test('producedFilesOmit ignores seeded fixtures', () => {
   const files = { ...seeded }
   assert.equal(scoreScenario(s, produced(files, seeded)).rate, 1)
 })
+
+test('a skill the session was never offered reports unavailability', () => {
+  const scenario = { id: 's', expect: { skill: 'vibekit:example-plain' } }
+  const run = { ...ok(), initSkills: ['vibekit:using-vibekit'] }
+  assert.match(scoreScenario(scenario, [run]).failures[0], /was not available/)
+})
+
+test('a skill that was offered and not invoked still reports never fired', () => {
+  const scenario = { id: 's', expect: { skill: 'vibekit:example-plain' } }
+  const run = { ...ok(), initSkills: ['vibekit:example-plain'] }
+  assert.match(scoreScenario(scenario, [run]).failures[0], /never fired/)
+})


### PR DESCRIPTION
## Summary

`evals/parse.mjs` counted a skill as fired whenever the assistant emitted a `Skill` tool_use block, without checking the call succeeded. A session could invoke a skill that does not exist, get back `Unknown skill`, and still be scored as having used it.

This makes a fired skill mean a loaded skill.

## The failure this fixes

Captured directly by running a session against a worktree predating the skill it was told to invoke:

```
TOOL_USE    name=Skill  input={"skill": "vibekit:plain"}
TOOL_RESULT is_error=true
   content="<tool_use_error>Unknown skill: vibekit:plain. Did you mean vibekit:plan?</tool_use_error>"
```

A successful call differs unambiguously. `is_error` is absent and the content reads `"Launching skill: vibekit:terse"`.

The consequence showed up in PR #34's numbers. In that cycle's M2 run the baseline arm used commit `67ae746`, where `skills/plain` does not exist in the tree, yet two scenarios recorded non-zero baselines:

| scenario | baseline recorded | correct value |
|---|---:|---:|
| `plain-omits-em-dash-in-artifact` | 0.2 | 0.0 |
| `plain-omits-semicolon` | 0.4 | 0.0 |

Seven of ten sessions were scored as firing a skill that was not there.

## Changes

**`evals/parse.mjs`** filters the `skills` list against `initSkills`, the skills the session's own init event says it was offered. A skill the runtime never offered cannot have loaded. Applied at result assembly so both return paths carry it, and so the init event's position in the stream cannot matter.

Filtering at parse time rather than at each expectation gives one definition of fired to all three consumers in `score.mjs`: `skill`, `after` and `skillAbsent`. `skillAbsent` is the sharp case. Under the old semantics a session that attempted an unavailable skill would fail a `skillAbsent` assertion for a skill that never loaded, which is backwards.

**`tools` and `dispatches` are deliberately not filtered**, and a test pins that. They record a decision the model made rather than guidance it received. An errored `Write` still means the session chose to write before designing, which is exactly what the `before` expectation at `evals/score.mjs` catches to enforce the brainstorm gate. Filtering there would let a session attempt and fail repeatedly while passing.

**`evals/score.mjs`** splits the failure reason, so a skill that was never offered reads differently from one the session declined to invoke:

```
offered elsewhere -> skill X was not available to the session
offered, not used -> skill X never fired
no init data      -> skill X never fired
```

The third branch matters. A run object carrying no init data says nothing either way, so it keeps the original wording rather than asserting something unobserved. It also keeps the existing test helper working, since that helper builds runs without an `initSkills` field.

**`evals/fixtures/skill-unavailable.jsonl`** is a new fixture trimmed from a real transcript: an init event offering two skills, an assistant invoking a third, and a result event.

## Verify

```
npm test        exit 0, 210 pass, 0 fail
npm run check   exit 0
git status      clean
diff scope      5 files, all claimed by a task
```

All five spec goals satisfied. Verdict `ready` against `2bd693a`.

Four new tests, one per property that could regress: the unavailable skill is not fired, the attempt is still in `tools`, unavailability reports distinctly, and an offered-but-unused skill still reports `never fired`.

## Comparability boundary

Every results file written before this counts attempts. Every file after counts loads. Nothing reconciles them, and that discontinuity is the intended effect rather than a cost.

The M-series from PR #34 is not re-run. Roughly 500 sessions to restate conclusions that do not change, since `plain` existed in those candidate arms and those calls succeeded. Only the three `plain-*` baseline arms were affected, and nothing gated on a baseline.

## Open

**The filter trusts the init event to be complete.** If the runtime ever offers a skill without listing it there, a genuine load is dropped and the scenario reports `was not available` for a skill that worked. Observed on four fixtures and two live transcripts, never on a case where the runtime omitted one.

**`skillAbsent` has no test of its own for the new semantics.** The behaviour is correct and is why parse-time was chosen over score-time, but no test pins that specific consumer.

**The new parser has never scored a live eval run.** The fixture proves the behaviour at parse time. The spec ruled out spending sessions to watch a rate move from 0.2 to 0.0.