### PR TITLE
Document the Antigravity install more findably

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Verify with `opencode debug skill`.
 agy plugin install https://github.com/rizukirr/vibekit
 ```
 
+Verify with `agy plugin list`. Re-run the install command to update.
+
 **Pi**
 
 ```

--- a/README.md
+++ b/README.md
@@ -82,13 +82,15 @@ Add it to the `plugin` array in your `opencode.json`, global or project level:
 
 Verify with `opencode debug skill`.
 
-**Antigravity**
+**Antigravity (`agy`)**
 
 ```
 agy plugin install https://github.com/rizukirr/vibekit
 ```
 
 Verify with `agy plugin list`. Re-run the install command to update.
+
+The install reports `hooks: skipped (not found)`, which is expected. vibekit's hook is Claude Code's `SessionStart`, and Antigravity has no session-start event: its five events are `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation` and `Stop`. The auto-trigger map reaches the model through `rules/AGENTS.md` instead, which Antigravity loads as always-on rules.
 
 **Pi**
 


### PR DESCRIPTION
Two documentation gaps found by reading the merged README as a new user would.

## The heading did not contain the command

Every other install heading matches its binary: Codex to `codex`, opencode to `opencode`, Pi to `pi`. Antigravity to `agy` was the one mismatch, so searching the README for `agy` found only the command inside the fenced block and nothing in the headings. The heading is now **Antigravity (`agy`)**.

Also adds the verify line the section was missing. Codex and opencode each tell the reader how to confirm the install landed, and `agy plugin list` is the exact equivalent.

## `hooks: skipped (not found)` reads like a defect

A successful install prints:

```
✔ skills      : 11 processed
- hooks       : skipped (not found)
```

vibekit does ship a hook, so that line invites the reasonable conclusion that something is broken. It is not. vibekit's hook is Claude Code's `SessionStart`, emitted by `runtimes/claude-code.mjs` and pointed at by the Codex manifest. Antigravity has no session-start event at all: its five events are `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation` and `Stop`. There is nothing to attach it to.

The auto-trigger map reaches the model through `rules/AGENTS.md`, which Antigravity loads as always-on rules, and which was verified reaching a live session during the runtime work. The README now says so at the point where a reader meets the line.

## Checks

`npm run check` and `npm test` both exit 0. Five lines added to `README.md`, no other file touched.

This is documentation only, so it did not go through spec and plan. It corrects wording in a file, adds no claim that was not already measured, and introduces no behaviour.