### PR TITLE
Supply-chain hygiene: security policy, pinned actions, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  # The repo ships no runtime dependencies, so Actions are the only update surface.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
 
@@ -37,9 +37,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security policy
+
+## Supported versions
+
+Only the latest published release receives fixes. vibekit ships skills and a SessionStart hook, with no server, no network calls and no runtime dependencies, so upgrading is replacing the plugin.
+
+## Reporting a vulnerability
+
+Report privately through [GitHub Security Advisories](https://github.com/rizukirr/vibekit/security/advisories/new). Do not open a public issue for a vulnerability.
+
+Include the affected version, the runtime you ran it under (Claude Code, Codex, opencode, Antigravity or pi), and the smallest reproduction you have. Expect an acknowledgement within seven days.
+
+## Scope
+
+In scope:
+
+- The SessionStart hook in `hooks/`, which is the one executable surface every runtime loads.
+- Generated manifests that could cause a runtime to load a file the repo did not intend to ship.
+- Skill instructions that would push an agent into an unsafe command without the user seeing it.
+
+Out of scope:
+
+- Behaviour of the coding agents themselves. A skill is instructions, and the runtime decides what it executes.
+- Anything requiring an already compromised machine or an attacker who can already edit the installed plugin directory.


### PR DESCRIPTION
Three repo-hygiene additions, no behaviour change.

- `SECURITY.md`: private reporting through GitHub Security Advisories, with scope drawn around the hook and the generated manifests, which are the only executable and load-bearing surfaces.
- `.github/workflows/ci.yml`: `actions/checkout` and `actions/setup-node` pinned to the commit each v4 tag points at today, tag kept as a trailing comment. No version bump.
- `.github/dependabot.yml`: weekly github-actions updates. Nothing else, because the repo ships no runtime dependencies.

## Why

The scanner gating https://github.com/hashgraph-online/awesome-ai-plugins/pull/229 scored this repo 74 against a threshold of 80. It counts each deduction once per runtime it scans, so these three cost roughly 33 points across claude, codex and opencode. They are worth having on their own terms.

Two deductions are deliberately left alone: no committed lockfile, since the repo has no dependencies to lock, and no `.codexignore`. A `high:3` shell-injection finding also remains, with no location attached because the run skipped its SARIF upload.

## Verification

```
npm run check   # up to date
npm test        # 217 pass, 0 fail
```